### PR TITLE
Add missing sequence

### DIFF
--- a/tools/cron.sh
+++ b/tools/cron.sh
@@ -43,6 +43,6 @@ psql -d $DATABASE -c "UPDATE dynpoi_item SET tags = (SELECT array_agg(tag)
 mkdir "$DIR_DUMP/tmp"
 mkdir "$DIR_DUMP/export"
 
-pg_dump -t dynpoi_categ -t dynpoi_class -t dynpoi_item -t dynpoi_update_last -t marker -t marker_elem -t marker_fix -t source $DATABASE \
+pg_dump -t dynpoi_status_id_seq -t dynpoi_categ -t dynpoi_class -t dynpoi_item -t dynpoi_update_last -t marker -t marker_elem -t marker_fix -t source $DATABASE \
   | bzip2 > "$DIR_DUMP/tmp/osmose-planet-latest.sql.bz2.tmp"
 mv "$DIR_DUMP/tmp/osmose-planet-latest.sql.bz2.tmp" "$DIR_DUMP/export/osmose-planet-latest.sql.bz2"


### PR DESCRIPTION
This adds the `dynpoi_status_id_seq` sequence which is missing and causes the database restore to fail.