### PR TITLE
Remove references to Gitorious

### DIFF
--- a/map.py
+++ b/map.py
@@ -142,7 +142,7 @@ def index(db, lang):
     helps.append((_("Contact"), "../contact"))
     helps.append((_("Help on wiki"), _("http://wiki.openstreetmap.org/wiki/Osmose")))
     helps.append((_("Copyright"), "../copyright"))
-    helps.append((_("Sources"), "https://gitorious.org/osmose"))
+    helps.append((_("Sources"), "https://github.com/osm-fr?query=osmose"))
     helps.append((_("Translation"), "../translation"))
 
     sql = """

--- a/po/osmose-frontend.pot
+++ b/po/osmose-frontend.pot
@@ -177,8 +177,8 @@ msgstr ""
 
 #: tmp.tpl:27
 msgid ""
-"Patches can be provided via merge requests on gitorious or github. This is "
-"the prefered way to handle patches."
+"Patches can be provided via merge requests on Github. This is the preferred "
+"way of handling patches."
 msgstr ""
 
 #: tmp.tpl:28

--- a/views/contact.tpl
+++ b/views/contact.tpl
@@ -3,13 +3,8 @@
 <p>{{! _("Bug should be reported on <a href='http://trac.openstreetmap.fr'>trac</a>. The component to pick should be osmose-frontend for issues around the website, and osmose-backend for issues on the reported issues on OSM data, or for suggestion for new analyses.")}}</p>
 
 <h1>{{_("Providing patches")}}</h1>
-<p>{{_("Patches can be provided via merge requests on gitorious or github. This is the prefered way to handle patches.")}}</p>
+<p>{{_("Patches can be provided via merge requests on Github. This is the preferred way of handling patches.")}}</p>
 <ul>
-  <li>Gitorious:
-  <ul>
-    <li> <a href="https://gitorious.org/osmose/backend">backend</a>
-    <li> <a href="https://gitorious.org/osmose/frontend">frontend</a>
-  </ul>
   <li>Github:
   <ul>
     <li> <a href="https://github.com/osm-fr/osmose-backend">backend</a>


### PR DESCRIPTION
Gitorious is now read-only, and out of date compared to the Github repo. I suggest removing all references to Gitorious, leaving only Github.