### PR TITLE
Allow using remote database server

### DIFF
--- a/osmose.py
+++ b/osmose.py
@@ -25,7 +25,7 @@ from bottle import SimpleTemplate
 SimpleTemplate.defaults["get_url"] = app.get_url
 
 import bottle_pgsql
-app.install(bottle_pgsql.Plugin("dbname='%s' user='%s' password='%s'" % (utils.pg_base, utils.pg_user, utils.pg_pass)))
+app.install(bottle_pgsql.Plugin("host='%s' port='%s' dbname='%s' user='%s' password='%s'" % (utils.pg_host, utils.pg_port, utils.pg_base, utils.pg_user, utils.pg_pass)))
 import bottle_gettext, os
 app.install(bottle_gettext.Plugin('osmose-frontend', os.path.join("po", "mo"), utils.allowed_languages))
 

--- a/osmose.py
+++ b/osmose.py
@@ -25,7 +25,7 @@ from bottle import SimpleTemplate
 SimpleTemplate.defaults["get_url"] = app.get_url
 
 import bottle_pgsql
-app.install(bottle_pgsql.Plugin("host='%s' port='%s' dbname='%s' user='%s' password='%s'" % (utils.pg_host, utils.pg_port, utils.pg_base, utils.pg_user, utils.pg_pass)))
+app.install(bottle_pgsql.Plugin(utils.db_string))
 import bottle_gettext, os
 app.install(bottle_gettext.Plugin('osmose-frontend', os.path.join("po", "mo"), utils.allowed_languages))
 

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -33,6 +33,8 @@ languages_name["sw"] = u"Kiswahili"
 languages_name["uk"] = u"Українська"
 
 allowed_languages = list(languages_name)
+pg_host           = ""
+pg_port           = "5432"
 pg_user           = "osmose"
 pg_pass           = "-osmose-"
 pg_base           = "osmose_frontend"
@@ -59,7 +61,7 @@ dir_results       = "/data/work/%s/results" % (username)
 def get_dbconn():
     import psycopg2.extras
 #    return psycopg2.connect(host="localhost", database = pg_base, user = pg_user, password = pg_pass)
-    db_string = "host='localhost' dbname='%s' user='%s' password='%s'" % (pg_base, pg_user, pg_pass)
+    db_string = "host='%s' port='%s' dbname='%s' user='%s' password='%s'" % (pg_host, pg_port, pg_base, pg_user, pg_pass)
     psycopg2.extensions.register_type(psycopg2.extensions.UNICODE)
     psycopg2.extensions.register_type(psycopg2.extensions.UNICODEARRAY)
     conn = psycopg2.extras.DictConnection(db_string)

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -38,6 +38,8 @@ pg_port           = "5432"
 pg_user           = "osmose"
 pg_pass           = "-osmose-"
 pg_base           = "osmose_frontend"
+db_string         = "host='%s' port='%s' dbname='%s' user='%s' password='%s'" % (pg_host, pg_port, pg_base, pg_user, pg_pass)
+
 website           = "osmose.openstreetmap.fr"
 
 main_project      = "OpenStreetMap"
@@ -61,7 +63,6 @@ dir_results       = "/data/work/%s/results" % (username)
 def get_dbconn():
     import psycopg2.extras
 #    return psycopg2.connect(host="localhost", database = pg_base, user = pg_user, password = pg_pass)
-    db_string = "host='%s' port='%s' dbname='%s' user='%s' password='%s'" % (pg_host, pg_port, pg_base, pg_user, pg_pass)
     psycopg2.extensions.register_type(psycopg2.extensions.UNICODE)
     psycopg2.extensions.register_type(psycopg2.extensions.UNICODEARRAY)
     conn = psycopg2.extras.DictConnection(db_string)


### PR DESCRIPTION
This is especially useful when using Docker, where each process has its own hostname.

Note that there is a slight change in behavior in ```tools/utils.py``` (and every ```tools/*``` that uses ```get_dbconn()```): by default, db_host is now ```""``` (empty string), where it was previously ```"localhost"```. This implies that the connection to Postgres is now done via Unix socket, instead of TCP/IP over the loopback interface.

I suppose this change has no drawbacks when both the WSGI app and the database are on the same machine, especially since ```osmose.py``` already uses the Unix socket (no ```"host="```).