### PR TITLE
Switched tiles to https when available. Removed borken mapquest tiles.

### DIFF
--- a/static/map/layers.js
+++ b/static/map/layers.js
@@ -4,7 +4,7 @@ var mapBases = {
   'Mapnik': L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {attribution: osmAttribution}),
   'ÖPNV Karte': L.tileLayer('http://tile.memomaps.de/tilegen/{z}/{x}/{y}.png'),
   'White background': L.tileLayer('https://a.layers.openstreetmap.fr/blanc.png'),
-  'Mapnik-osmfr': L.tileLayer('https://tile-{s}.openstreetmap.fr/osmfr/{z}/{x}/{y}.png', {subdomains:"abc",attribution: osmAttribution}),
+  'Mapnik-osmfr': L.tileLayer('https://tile-{s}.openstreetmap.fr/osmfr/{z}/{x}/{y}.png', {attribution: osmAttribution}),
   'HOT': L.tileLayer('https://tile-{s}.openstreetmap.fr/hot/{z}/{x}/{y}.png', {attribution: osmAttribution}),
   'Bing': L.bingLayer('AmQcQsaJ4WpRqn2_k0rEToboqaM1ind8HMmM0XwKwW9R8bChmHEbczHwjnjFpuNP', {type: 'Aerial'}),
   'MapBox Satellite': L.tileLayer('https://{s}.tiles.mapbox.com/v4/openstreetmap.map-inh7ifmo/{z}/{x}/{y}.png?access_token=pk.eyJ1Ijoib3BlbnN0cmVldG1hcCIsImEiOiJhNVlHd29ZIn0.ti6wATGDWOmCnCYen-Ip7Q'),

--- a/static/map/layers.js
+++ b/static/map/layers.js
@@ -1,14 +1,13 @@
 var osmAttribution = '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors';
 var mapBases = {
   // OpenStreetMap
-  'Mapnik': L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {attribution: osmAttribution}),
-  'MapQuest Open': L.tileLayer('http://otile{s}.mqcdn.com/tiles/1.0.0/osm/{z}/{x}/{y}.png', {subdomains: '123', attribution: osmAttribution + " - Tiles Courtesy of <a href=\"http://www.mapquest.com/\" target=\"_blank\">MapQuest</a> <img src=\"http://developer.mapquest.com/content/osm/mq_logo.png\">"}),
+  'Mapnik': L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {attribution: osmAttribution}),
   'ÖPNV Karte': L.tileLayer('http://tile.memomaps.de/tilegen/{z}/{x}/{y}.png'),
-  'White background': L.tileLayer('http://a.layers.openstreetmap.fr/blanc.png'),
-  'Mapnik-osmfr': L.tileLayer('http://{s}.tile.openstreetmap.fr/osmfr/{z}/{x}/{y}.png', {attribution: osmAttribution}),
-  'HOT': L.tileLayer('http://{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png', {attribution: osmAttribution}),
+  'White background': L.tileLayer('https://a.layers.openstreetmap.fr/blanc.png'),
+  'Mapnik-osmfr': L.tileLayer('https://tile-{s}.openstreetmap.fr/osmfr/{z}/{x}/{y}.png', {subdomains:"abc",attribution: osmAttribution}),
+  'HOT': L.tileLayer('https://tile-{s}.openstreetmap.fr/hot/{z}/{x}/{y}.png', {attribution: osmAttribution}),
   'Bing': L.bingLayer('AmQcQsaJ4WpRqn2_k0rEToboqaM1ind8HMmM0XwKwW9R8bChmHEbczHwjnjFpuNP', {type: 'Aerial'}),
-  'MapBox Satellite': L.tileLayer('http://{s}.tiles.mapbox.com/v4/openstreetmap.map-inh7ifmo/{z}/{x}/{y}.png?access_token=pk.eyJ1Ijoib3BlbnN0cmVldG1hcCIsImEiOiJhNVlHd29ZIn0.ti6wATGDWOmCnCYen-Ip7Q'),
+  'MapBox Satellite': L.tileLayer('https://{s}.tiles.mapbox.com/v4/openstreetmap.map-inh7ifmo/{z}/{x}/{y}.png?access_token=pk.eyJ1Ijoib3BlbnN0cmVldG1hcCIsImEiOiJhNVlHd29ZIn0.ti6wATGDWOmCnCYen-Ip7Q'),
   // OpenGeoFiction
   //'Standard': L.tileLayer('http://opengeofiction.net/osm_tiles/{z}/{x}/{y}.png', {attribution: osmAttribution}),
   //'TopoMap': L.tileLayer('http://opengeofiction.net/tiles-topo/{z}/{x}/{y}.png', {attribution: osmAttribution}),


### PR DESCRIPTION
If tiles are available over https, this PR will request them over https instead of http. This also removes a couple of console warnings.

Mapquest tiles aren't available anymore. I used the opportunity to remove them.

( Protocol-relative URLs shouldn't be used - https://www.paulirish.com/2010/the-protocol-relative-url/)