### PR TITLE
fix: do not add slash twice when redirecting to URL

### DIFF
--- a/bottle_gettext.py
+++ b/bottle_gettext.py
@@ -88,7 +88,9 @@ class GettextPlugin(object):
                 new_url.append(url.scheme)
                 new_url.append("://")
                 new_url.append(utils.website)
-                new_url.append("/" + language[0])
+                if not utils.website.endswith("/"):
+                    new_url.append("/")
+                new_url.append(language[0])
                 new_url.append(request.fullpath)
                 if url.query:
                     new_url.append("?")


### PR DESCRIPTION
Fix #74, it was due to [the Dockerfile](https://github.com/osm-fr/osmose-frontend/blob/master/Dockerfile#L29)
  