### PR TITLE
Rework the navbar with bootstrap.

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,3 +1,8 @@
+[dir="rtl"] .dropdown-menu {
+  right: 0;
+  text-align: right;
+}
+
 body {
   text-align: inherit;
 }

--- a/static/map/Osmose.Export.js
+++ b/static/map/Osmose.Export.js
@@ -24,7 +24,7 @@ const OsmoseExport = L.Class.extend({
     this._params_last = params;
     params.limit = 500;
     params.bbox = this._map.getBounds().toBBoxString();
-    $('#menu-export ul a').each((i, a) => {
+    $('#menu-export div a').each((i, a) => {
       a.href = $(a).data('href') + L.Util.getParamString(params);
     });
   },

--- a/static/map/style.css
+++ b/static/map/style.css
@@ -10,7 +10,7 @@ body {
 /* Map */
 div#map {
   position: absolute;
-  top: 23px;
+  top: 56px;
   bottom: 0px;
   left: 0px;
   right: 0px;
@@ -25,85 +25,10 @@ div#map div#spinner {
 }
 
 /* Top menu */
-div#top_links {
-  background-color: #FFFFFF;
-  box-shadow: 0 1px 5px rgba(0, 0, 0, 0.65);
-  position: absolute;
-  height: 24px;
-  width: 100%;
-  left: 0px;
-  top: 0px;
-  opacity: 0.9;
-  font-size: 13px;
-
-  vertical-align: middle;
-  text-align: center;
+#top_links {
   z-index: 1025;
 }
 
-.leaflet-touch + div#top_links {
-  box-shadow: none;
-  border-bottom: 2px solid rgba(0,0,0,0.2);
-  background-clip: padding-box;
-}
-
-#topmenu {
-  list-style-type: none;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  position: absolute;
-  top: 0;
-}
-#topmenu li {
-  display: inline-block;
-  vertical-align: top;
-  margin: 0;
-  padding: 0;
-  border: 0;
-}
-#topmenu li a:link,
-#topmenu li a:visited {
-  display: block;
-  margin: 0;
-  padding: 2px 8px;
-  border-right: 1px solid #CCCCCC;
-  text-decoration: none;
-}
-#topmenu li a:hover
-#topmenu li a:active {
-  background-color: #B0B0B0;
-}
-
-#topmenu .submenu {
-  display: none;
-  list-style-type: none;
-  margin: 0;
-  padding: 0;
-  border: 0;
-}
-#topmenu .submenu li {
-  display: block;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  border-top: 1px solid #003453;
-  border-right: 1px solid #003453;
-}
-#topmenu .submenu li a:link,
-#topmenu .submenu li a:visited {
-  display: block;
-  margin: 0;
-  border: 0;
-  text-decoration: none;
-  background: #DDDDDD;
-}
-#topmenu .submenu li a:hover {
-  background-image: none;
-  background-color: #B0B0B0;
-}
- 
-#topmenu li:hover > .submenu { display: block; }
 
 /* popups */
 
@@ -247,24 +172,6 @@ ul.leaflet-control-geocoder-alternatives {
   left: 300px;
   right: 0px;
   bottom: 0px;
-}
-
-@media(max-width:399px) {
-  #topmenu #menu-lang, #topmenu #menu-openstreetmapfr, #topmenu #menu-byuser, #topmenu #menu-relation_analyser, #topmenu #menu-statistics, #topmenu #menu-help, #topmenu #menu-delay {
-    display: none;
-  }
-}
-
-@media(min-width:400px) and (max-width:767px) {
-  #topmenu #menu-byuser, #topmenu #menu-relation_analyser, #topmenu #menu-statistics, #topmenu #menu-help, #topmenu #menu-delay {
-    display: none;
-  }
-}
-
-@media(min-width:768px) and (max-width:991px) {
-  #topmenu #menu-byuser, #topmenu #menu-relation_analyser, #topmenu#menu-statistics, #topmenu #menu-help {
-    display: none;
-  }
 }
 
 @media(min-width:768px) and (max-width:991px) {

--- a/views/map/index.tpl
+++ b/views/map/index.tpl
@@ -184,7 +184,7 @@
     </ul>
     %delay_status = "success" if delay < 0.9 else "warning" if delay < 1.6 else "danger"
     %delay = "%0.2f" % delay
-    <a href="../control/update" class="nav-link" data-toggle="tooltip" title="{{_("Delay: %sd") % delay}}"><span class="badge badge-pill badge-{{delay_status}}"> </span></a>
+    <a href="../control/update" class="nav-link"><span class="badge  badge-{{delay_status}}">{{_("Delay: %sd") % delay}}</span></a>
   </div>
 </nav>
 

--- a/views/map/index.tpl
+++ b/views/map/index.tpl
@@ -113,73 +113,85 @@
 <div id="map">
 </div>
 
-<div id='top_links'>
-<ul id="topmenu">
-<li id="menu-lang"><a href='#' onclick='return false;'>{{_("Change language")}} ▼</a>
-<ul class="submenu">
-%for (k, v) in languages_name.items():
-%    if translate.languages[0] == k:
-%        s = " class='bold'"
-%    else:
-%        s = ""
-%    end
-  <li{{!s}}><a href="{{"http://" + website + "/" + k + request.path + "?" + request.query_string}}">{{v}} ({{k}})</a></li>
-%end
-</ul>
-</li>
 
-%for u in urls:
- <li id="menu-{{u[0]}}"><a href="{{u[2]}}">{{u[1]}}</a></li>
-%end
+<nav id="top_links" class="navbar navbar-expand-lg navbar-light bg-light">
+  <a class="navbar-brand" href="/">Osmose</a>
 
-<li id="menu-export"><a href='#' onclick='return false;'>{{_("Export")}} ▼</a>
-<ul class="submenu">
-  <li><a data-href="../errors/" target="_blank">{{_("Html list")}}</a></li>
-  <li><a data-href="../josm_proxy?errors.josm" target="hiddenIframe">JOSM</a></li>
-  <li><a data-href="../errors.rss" target="_blank">RSS</a></li>
-  <li><a data-href="../errors.gpx">GPX</a></li>
-  <li><a data-href="../errors.kml">KML</a></li>
-  <li><a data-href="../api/0.2/errors" target="_blank">Json</a></li>
-  <li><a data-href="../errors.csv" target="_blank">CSV</a></li>
-  <li><a data-href="markers" target="_blank">GeoJson</a></li>
-</ul>
+  <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+    <span class="navbar-toggler-icon"></span>
+  </button>
 
-<li id="menu-help"><a href='#' onclick='return false;'>{{_("Help")}} ▼</a>
-<ul class="submenu">
-%for u in helps:
- <li><a href="{{u[1]}}">{{u[0]}}</a></li>
-%end
-</ul>
-</li>
+  <div class="collapse navbar-collapse" id="navbarSupportedContent">
+    <ul class="navbar-nav mr-auto">
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle" href="#" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{{_("Change language")}}</a>
+        <div class="dropdown-menu">
+          %for (k, v) in languages_name.items():
+          %    if translate.languages[0] == k:
+          %        s = "bold"
+          %    else:
+          %        s = ""
+          %    end
+          <a class="dropdown-item {{s}}" href="{{"http://" + website + "/" + k + request.path + "?" + request.query_string}}">{{v}} ({{k}})</a>
+          %end
+        </div>
+      </li>
 
-%delay_status = "normal" if delay < 0.9 else "warning" if delay < 1.6 else "error"
-%delay = "%0.2f" % delay
-<li id="menu-delay"><a href="../control/update" class="delay-{{delay_status}}">{{_("Delay: %sd") % delay}}</a></li>
+      %for u in urls:
+       <li class="nav-item"><a class="nav-link" href="{{u[2]}}">{{u[1]}}</a></li>
+      %end
 
-<li id="menu-user">
-%if user:
-  <a href="../byuser/{{user}}">{{user}} ({{user_error_count[1]+user_error_count[2]+user_error_count[3]}}) ▼</a>
-  <ul class="submenu">
-    <li><a href="../byuser/{{user}}?level=1">{{_("Level {level} issues ({count})") .format(level=1, count=user_error_count[1])}}</a></li>
-    <li><a href="../byuser/{{user}}?level=2">{{_("Level {level} issues ({count})") .format(level=2, count=user_error_count[2])}}</a></li>
-    <li><a href="../byuser/{{user}}?level=3">{{_("Level {level} issues ({count})") .format(level=3, count=user_error_count[3])}}</a></li>
-    <li><a href="../logout">{{_("Logout")}}</a></li>
-  </ul>
-%else:
-  <a href="../login">{{_("Login")}}</a>
-%end
-</li>
+      <li class="nav-item dropdown" id="menu-export">
+        <a class="nav-link dropdown-toggle" href="#" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{{_("Export")}}</a>
+        <div class="dropdown-menu">
+          <a class="dropdown-item" data-href="../errors/" target="_blank">{{_("Html list")}}</a>
+          <a class="dropdown-item" data-href="../josm_proxy?errors.josm" target="hiddenIframe">JOSM</a>
+          <a class="dropdown-item" data-href="../errors.rss" target="_blank">RSS</a>
+          <a class="dropdown-item" data-href="../errors.gpx">GPX</a>
+          <a class="dropdown-item" data-href="../errors.kml">KML</a>
+          <a class="dropdown-item" data-href="../api/0.2/errors" target="_blank">Json</a>
+          <a class="dropdown-item" data-href="../errors.csv" target="_blank">CSV</a>
+          <a class="dropdown-item" data-href="markers" target="_blank">GeoJson</a>
+        </div>
+      </li>
 
-<li id="menu-editor-save" style="display:none">
-  <a href="#">{{_("Save")}} (<span id="menu-editor-save-number"></span>)</a>
-</li>
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle" href="#" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{{_("Help")}}</a>
+        <div class="dropdown-menu">
+          %for u in helps:
+          <a class="dropdown-item" href="{{u[1]}}">{{u[0]}}</a>
+          %end
+        </div>
+      </li>
 
-</ul>
-</div>
+      %if user:
+      <li class="nav-item dropdown">
+        <a href="../byuser/{{user}}">{{user}} ({{user_error_count[1]+user_error_count[2]+user_error_count[3]}}) ▼</a>
+        <div class="dropdown-menu">
+          <a class="dropdown-item" href="../byuser/{{user}}?level=1">{{_("Level {level} issues ({count})") .format(level=1, count=user_error_count[1])}}</a>
+          <a class="dropdown-item" href="../byuser/{{user}}?level=2">{{_("Level {level} issues ({count})") .format(level=2, count=user_error_count[2])}}</a>
+          <a class="dropdown-item" href="../byuser/{{user}}?level=3">{{_("Level {level} issues ({count})") .format(level=3, count=user_error_count[3])}}</a>
+          <a class="dropdown-item" href="../logout">{{_("Logout")}}</a>
+        </div>
+      </li>
+      %else:
+      <li class="nav-item"><a class="nav-link" href="../login">{{_("Login")}}</a></li>
+      %end
+
+      <li class="nav-item" id="menu-editor-save" style="display:none">
+        <a href="#">{{_("Save")}} (<span id="menu-editor-save-number"></span>)</a>
+      </li>
+    </ul>
+    %delay_status = "success" if delay < 0.9 else "warning" if delay < 1.6 else "danger"
+    %delay = "%0.2f" % delay
+    <a href="../control/update" class="nav-link" data-toggle="tooltip" title="{{_("Delay: %sd") % delay}}"><span class="badge badge-pill badge-{{delay_status}}"> </span></a>
+  </div>
+</nav>
 
 <script type="text/javascript">
 $(function() {
   initMap();
+  $('[data-toggle="tooltip"]').tooltip();
 });
 </script>
 

--- a/views/map/index.tpl
+++ b/views/map/index.tpl
@@ -166,7 +166,7 @@
 
       %if user:
       <li class="nav-item dropdown">
-        <a href="../byuser/{{user}}">{{user}} ({{user_error_count[1]+user_error_count[2]+user_error_count[3]}}) ▼</a>
+        <a class="nav-link dropdown-toggle" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" href="../byuser/{{user}}">{{user}} ({{user_error_count[1]+user_error_count[2]+user_error_count[3]}}) ▼</a>
         <div class="dropdown-menu">
           <a class="dropdown-item" href="../byuser/{{user}}?level=1">{{_("Level {level} issues ({count})") .format(level=1, count=user_error_count[1])}}</a>
           <a class="dropdown-item" href="../byuser/{{user}}?level=2">{{_("Level {level} issues ({count})") .format(level=2, count=user_error_count[2])}}</a>


### PR DESCRIPTION
Since the osmose discussion this week end @sotmfr, I started some work to improve the UX/UI. 

My first take is the navbar. It's now use Bootstrap. Also the delay is now displayed with only a badge and a tooltip to display the details (green, orange, red).

I few thinks that I would like to discuss:

- Remove the link to the "Relation Analyzer", as there is always a 500
- A logo to display next to the project name (the one from twitter ?)

The result:

![osmose-menu](https://user-images.githubusercontent.com/86659/59568306-3835c000-9079-11e9-8a58-6b68a72661af.gif)
