### PR TITLE
Open issue popup on map load

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,4 @@ web/static/osmose-coverage.topojson.pbf*
 web/node_modules
 osmose-frontend-venv
 
-web/webpack.bundle-*.js
-web/webpack.bundle-*.js.map
+web/**/webpack.bundle-*.js*

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ web/node_modules
 osmose-frontend-venv
 
 web/**/webpack.bundle-*.js*
+web/webpack.stats.json

--- a/web/static/map/Osmose.Export.js
+++ b/web/static/map/Osmose.Export.js
@@ -21,7 +21,7 @@ const OsmoseExport = L.Class.extend({
     const params = Object.assign({}, e.params);
     delete params.lat;
     delete params.lon;
-    delete params.marker_uuid;
+    delete params.issue_uuid;
     this._params_last = params;
     params.limit = 500;
     params.bbox = this._map.getBounds().toBBoxString();

--- a/web/static/map/Osmose.Export.js
+++ b/web/static/map/Osmose.Export.js
@@ -21,7 +21,7 @@ const OsmoseExport = L.Class.extend({
     const params = Object.assign({}, e.params);
     delete params.lat;
     delete params.lon;
-    delete params.errorId;
+    delete params.marker_uuid;
     this._params_last = params;
     params.limit = 500;
     params.bbox = this._map.getBounds().toBBoxString();

--- a/web/static/map/Osmose.Export.js
+++ b/web/static/map/Osmose.Export.js
@@ -21,6 +21,7 @@ const OsmoseExport = L.Class.extend({
     const params = Object.assign({}, e.params);
     delete params.lat;
     delete params.lon;
+    delete params.errorId;
     this._params_last = params;
     params.limit = 500;
     params.bbox = this._map.getBounds().toBBoxString();

--- a/web/static/map/Osmose.Marker.js
+++ b/web/static/map/Osmose.Marker.js
@@ -14,7 +14,6 @@ require('./Osmose.Marker.css');
 const OsmoseMarker = L.VectorGrid.Protobuf.extend({
 
   initialize(permalink, params, editor, doc, featuresLayers, options) {
-    this.opened_initial_issue = false;
     this._permalink = permalink;
     this._editor = editor;
     this._doc = doc;
@@ -49,11 +48,9 @@ const OsmoseMarker = L.VectorGrid.Protobuf.extend({
         return f.properties.uuid;
       },
     };
-    this.on('load', (e) => {
-      if (params.issue_uuid && !this.opened_initial_issue) {
+    this.on('add', (e) => {
+      if (params.issue_uuid) {
         this._openPopup(params.issue_uuid, [params.lat, params.lon], this);
-        // Disarm initial popup opening on further vector tile loads
-        this.opened_initial_issue = true;
       }
     });
     L.VectorGrid.Protobuf.prototype.initialize.call(this, this._buildUrl(params), vectorTileOptions);

--- a/web/static/map/Osmose.Marker.js
+++ b/web/static/map/Osmose.Marker.js
@@ -14,6 +14,7 @@ require('./Osmose.Marker.css');
 const OsmoseMarker = L.VectorGrid.Protobuf.extend({
 
   initialize(permalink, params, editor, doc, featuresLayers, options) {
+    this.opened_initial_issue = false;
     this._permalink = permalink;
     this._editor = editor;
     this._doc = doc;
@@ -48,6 +49,15 @@ const OsmoseMarker = L.VectorGrid.Protobuf.extend({
         return f.properties.uuid;
       },
     };
+    this.on('load', (e) => {
+      if (params.errorId && !this.opened_initial_issue) {
+        // Hack : This should use error coordinates from osmose api coordinates
+        // instead of trusting URL params
+        this._openPopup(params.errorId, [params.lat, params.lon], this);
+        // Disarm initial popup opening on further vector tile loads
+        this.opened_initial_issue = true;
+      }
+    });
     L.VectorGrid.Protobuf.prototype.initialize.call(this, this._buildUrl(params), vectorTileOptions);
   },
 

--- a/web/static/map/Osmose.Marker.js
+++ b/web/static/map/Osmose.Marker.js
@@ -50,8 +50,8 @@ const OsmoseMarker = L.VectorGrid.Protobuf.extend({
       },
     };
     this.on('load', (e) => {
-      if (params.marker_uuid && !this.opened_initial_issue) {
-        this._openPopup(params.marker_uuid, [params.lat, params.lon], this);
+      if (params.issue_uuid && !this.opened_initial_issue) {
+        this._openPopup(params.issue_uuid, [params.lat, params.lon], this);
         // Disarm initial popup opening on further vector tile loads
         this.opened_initial_issue = true;
       }
@@ -94,7 +94,7 @@ const OsmoseMarker = L.VectorGrid.Protobuf.extend({
     this.on('click', click);
 
     this._map.on('popupclose', (e) => {
-      this._permalink.update_item({ marker_uuid: null });
+      this._permalink.update_item({ issue_uuid: null });
     });
 
 
@@ -154,7 +154,7 @@ const OsmoseMarker = L.VectorGrid.Protobuf.extend({
       return;
     }
     this.open_popup = uuid;
-    this._permalink.update_item({ marker_uuid: uuid });
+    this._permalink.update_item({ issue_uuid: uuid });
 
     const popup = L.responsivePopup({
       maxWidth: 280,

--- a/web/static/map/Osmose.Marker.js
+++ b/web/static/map/Osmose.Marker.js
@@ -159,7 +159,7 @@ const OsmoseMarker = L.VectorGrid.Protobuf.extend({
     const popup = L.responsivePopup({
       maxWidth: 280,
       autoPan: false,
-      offset: L.point(0, -8),
+      offset: L.point(0, 24),
     }).setLatLng(initialLatlng)
       .setContent("<center><img src='../images/throbbler.gif' alt='downloading'></center>")
       .openOn(this._map);

--- a/web/static/map/Osmose.Marker.js
+++ b/web/static/map/Osmose.Marker.js
@@ -90,7 +90,7 @@ const OsmoseMarker = L.VectorGrid.Protobuf.extend({
           this._closePopup();
         } else {
           this.highlight = e.layer.properties.uuid;
-          this._openPopup(e);
+          this._openPopup(e.layer.properties.uuid, e.latlng, e.layer);
         }
       }
     };
@@ -147,17 +147,17 @@ const OsmoseMarker = L.VectorGrid.Protobuf.extend({
     }
   },
 
-  _openPopup(e) {
-    if (this.open_popup === e.layer.properties.uuid) {
+  _openPopup(uuid, latlng, layer) {
+    if (this.open_popup === uuid) {
       return;
     }
-    this.open_popup = e.layer.properties.uuid;
+    this.open_popup = uuid;
 
     const popup = L.responsivePopup({
       maxWidth: 280,
       autoPan: false,
       offset: L.point(0, -8),
-    }).setLatLng(e.latlng)
+    }).setLatLng(latlng)
       .setContent("<center><img src='../images/throbbler.gif' alt='downloading'></center>")
       .openOn(this._map);
     this.popup = popup;
@@ -166,7 +166,7 @@ const OsmoseMarker = L.VectorGrid.Protobuf.extend({
       if (popup.isOpen) {
         // Popup still open, so download content
         $.ajax({
-          url: `/api/0.3/issue/${e.layer.properties.uuid}?langs=auto`,
+          url: `/api/0.3/issue/${uuid}?langs=auto`,
           dataType: 'json',
           success: (data) => {
             data.elems_id = data.elems.map(elem => elem.type + elem.id).join(',');
@@ -207,7 +207,7 @@ const OsmoseMarker = L.VectorGrid.Protobuf.extend({
             const content = $(Mustache.render(template, data));
             content.on('click', '.closePopup', () => {
               setTimeout(() => {
-                this.corrected(e.layer);
+                this.corrected(layer);
               }, 200);
             });
             content.on('click', '.popup_help', (event) => {
@@ -215,7 +215,7 @@ const OsmoseMarker = L.VectorGrid.Protobuf.extend({
               return false;
             });
             content.on('click', '.editor_edit, .editor_fix', (event) => {
-              this._editor.edit(e.layer, event.currentTarget.getAttribute('data-error'), event.currentTarget.getAttribute('data-type'), event.currentTarget.getAttribute('data-id'), event.currentTarget.getAttribute('data-fix'));
+              this._editor.edit(layer, event.currentTarget.getAttribute('data-error'), event.currentTarget.getAttribute('data-type'), event.currentTarget.getAttribute('data-id'), event.currentTarget.getAttribute('data-fix'));
               return false;
             });
             popup.setContent(content[0]);

--- a/web/static/map/Osmose.Marker.js
+++ b/web/static/map/Osmose.Marker.js
@@ -50,10 +50,10 @@ const OsmoseMarker = L.VectorGrid.Protobuf.extend({
       },
     };
     this.on('load', (e) => {
-      if (params.errorId && !this.opened_initial_issue) {
+      if (params.marker_uuid && !this.opened_initial_issue) {
         // Hack : This should use error coordinates from osmose api coordinates
         // instead of trusting URL params
-        this._openPopup(params.errorId, [params.lat, params.lon], this);
+        this._openPopup(params.marker_uuid, [params.lat, params.lon], this);
         // Disarm initial popup opening on further vector tile loads
         this.opened_initial_issue = true;
       }
@@ -107,7 +107,7 @@ const OsmoseMarker = L.VectorGrid.Protobuf.extend({
     this.on('click', click);
 
     this._map.on('popupclose', (e) => {
-      this._permalink.update_item({ errorId: null });
+      this._permalink.update_item({ marker_uuid: null });
     });
 
 
@@ -167,7 +167,7 @@ const OsmoseMarker = L.VectorGrid.Protobuf.extend({
       return;
     }
     this.open_popup = uuid;
-    this._permalink.update_item({ errorId: uuid });
+    this._permalink.update_item({ marker_uuid: uuid });
 
     const popup = L.responsivePopup({
       maxWidth: 280,

--- a/web/static/map/Osmose.Marker.js
+++ b/web/static/map/Osmose.Marker.js
@@ -150,11 +150,6 @@ const OsmoseMarker = L.VectorGrid.Protobuf.extend({
   },
 
   _openPopup(uuid, initialLatlng, layer) {
-    // Hack : Move viewport back to bounds
-    // to allow display of OSM data and popup
-    if (initialLatlng[1] < -180 || initialLatlng[1] > 180) {
-      this._map.panTo([initialLatlng[0], initialLatlng[1] % 180]);
-    }
     if (this.open_popup === uuid) {
       return;
     }

--- a/web/static/map/Osmose.Marker.js
+++ b/web/static/map/Osmose.Marker.js
@@ -51,8 +51,6 @@ const OsmoseMarker = L.VectorGrid.Protobuf.extend({
     };
     this.on('load', (e) => {
       if (params.marker_uuid && !this.opened_initial_issue) {
-        // Hack : This should use error coordinates from osmose api coordinates
-        // instead of trusting URL params
         this._openPopup(params.marker_uuid, [params.lat, params.lon], this);
         // Disarm initial popup opening on further vector tile loads
         this.opened_initial_issue = true;
@@ -162,7 +160,7 @@ const OsmoseMarker = L.VectorGrid.Protobuf.extend({
     }
   },
 
-  _openPopup(uuid, latlng, layer) {
+  _openPopup(uuid, initialLatlng, layer) {
     if (this.open_popup === uuid) {
       return;
     }
@@ -173,7 +171,7 @@ const OsmoseMarker = L.VectorGrid.Protobuf.extend({
       maxWidth: 280,
       autoPan: false,
       offset: L.point(0, -8),
-    }).setLatLng(latlng)
+    }).setLatLng(initialLatlng)
       .setContent("<center><img src='../images/throbbler.gif' alt='downloading'></center>")
       .openOn(this._map);
     this.popup = popup;
@@ -185,6 +183,7 @@ const OsmoseMarker = L.VectorGrid.Protobuf.extend({
           url: `/api/0.3/issue/${uuid}?langs=auto`,
           dataType: 'json',
           success: (data) => {
+            popup.setLatLng([data.lat, data.lon]);
             data.elems_id = data.elems.map(elem => elem.type + elem.id).join(',');
 
             this._doc.load(data.item, data['class']);

--- a/web/static/map/Osmose.Marker.js
+++ b/web/static/map/Osmose.Marker.js
@@ -106,6 +106,11 @@ const OsmoseMarker = L.VectorGrid.Protobuf.extend({
     };
     this.on('click', click);
 
+    this._map.on('popupclose', (e) => {
+      this._permalink.update_item({ errorId: null });
+    });
+
+
     map.on('zoomend moveend', L.Util.bind(this._mapChange, this));
     const bindClosePopup = L.Util.bind(this._closePopup, this);
     map.on('zoomstart', bindClosePopup);
@@ -162,6 +167,7 @@ const OsmoseMarker = L.VectorGrid.Protobuf.extend({
       return;
     }
     this.open_popup = uuid;
+    this._permalink.update_item({ errorId: uuid });
 
     const popup = L.responsivePopup({
       maxWidth: 280,

--- a/web/static/map/Osmose.Marker.js
+++ b/web/static/map/Osmose.Marker.js
@@ -150,6 +150,11 @@ const OsmoseMarker = L.VectorGrid.Protobuf.extend({
   },
 
   _openPopup(uuid, initialLatlng, layer) {
+    // Hack : Move viewport back to bounds
+    // to allow display of OSM data and popup
+    if (initialLatlng[1] < -180 || initialLatlng[1] > 180) {
+      this._map.panTo([initialLatlng[0], initialLatlng[1] % 180]);
+    }
     if (this.open_popup === uuid) {
       return;
     }
@@ -172,9 +177,7 @@ const OsmoseMarker = L.VectorGrid.Protobuf.extend({
           url: `/api/0.3/issue/${uuid}?langs=auto`,
           dataType: 'json',
           success: (data) => {
-            // "Unwrap" API Coordinates if user pan map out of projection bounds
-            const wrapCount = Math.floor(parseFloat(initialLatlng[1]) / 360);
-            popup.setLatLng([data.lat, parseFloat(data.lon) + wrapCount * 360]);
+            popup.setLatLng([data.lat, data.lon]);
             data.elems_id = data.elems.map(elem => elem.type + elem.id).join(',');
 
             this._doc.load(data.item, data['class']);

--- a/web/static/map/Osmose.Marker.js
+++ b/web/static/map/Osmose.Marker.js
@@ -92,6 +92,8 @@ const OsmoseMarker = L.VectorGrid.Protobuf.extend({
 
     this._map.on('popupclose', (e) => {
       this._permalink.update_item({ issue_uuid: null });
+      this.open_popup = null;
+      this._featuresLayers.clearLayers();
     });
 
 
@@ -174,7 +176,6 @@ const OsmoseMarker = L.VectorGrid.Protobuf.extend({
 
             this._doc.load(data.item, data['class']);
             // Get the OSM objects
-            this._featuresLayers.clearLayers();
             if (data.elems_id) {
               let shift = -1; const palette = ['#ff3333', '#59b300', '#3388ff']; const
                 colors = {};

--- a/web/static/map/Osmose.Marker.js
+++ b/web/static/map/Osmose.Marker.js
@@ -79,17 +79,6 @@ const OsmoseMarker = L.VectorGrid.Protobuf.extend({
   onAdd(map) {
     this._map = map;
     L.GridLayer.prototype.onAdd.call(this, map);
-    /*
-    this.on('mouseover', (e) => {
-      if (e.layer.properties.uuid) {
-        this._openPopup(e);
-      }
-    }).on('mouseout', (e) => {
-      if (e.layer.properties.uuid && this.highlight != e.layer.properties.uuid) {
-        this._closePopup();
-      }
-    });
-*/
     const click = (e) => {
       if (e.layer.properties.limit) {
         map.setZoomAround(e.latlng, map.getZoom() + 1);

--- a/web/static/map/Osmose.Marker.js
+++ b/web/static/map/Osmose.Marker.js
@@ -87,7 +87,7 @@ const OsmoseMarker = L.VectorGrid.Protobuf.extend({
           this._closePopup();
         } else {
           this.highlight = e.layer.properties.uuid;
-          this._openPopup(e.layer.properties.uuid, e.latlng, e.layer);
+          this._openPopup(e.layer.properties.uuid, [e.latlng.lat, e.latlng.lng], e.layer);
         }
       }
     };
@@ -172,7 +172,9 @@ const OsmoseMarker = L.VectorGrid.Protobuf.extend({
           url: `/api/0.3/issue/${uuid}?langs=auto`,
           dataType: 'json',
           success: (data) => {
-            popup.setLatLng([data.lat, data.lon]);
+            // "Unwrap" API Coordinates if user pan map out of projection bounds
+            const wrapCount = Math.floor(parseFloat(initialLatlng[1]) / 360);
+            popup.setLatLng([data.lat, parseFloat(data.lon) + wrapCount * 360]);
             data.elems_id = data.elems.map(elem => elem.type + elem.id).join(',');
 
             this._doc.load(data.item, data['class']);

--- a/web/static/map/map.js
+++ b/web/static/map/map.js
@@ -48,6 +48,7 @@ export function initMap() {
     center: new L.LatLng(urlVars.lat, urlVars.lon),
     zoom: urlVars.zoom,
     layers: layers[0],
+    worldCopyJump: true,
   }).setActiveArea('leaflet-active-area', true);
 
   // Editor

--- a/web/static/map/map.js
+++ b/web/static/map/map.js
@@ -37,6 +37,7 @@ export function initMap() {
   urlVars.level = urlVars.level || Cookies.get('last_level') || '1';
   urlVars.tags = urlVars.tags || Cookies.get('last_tags');
   urlVars.fixable = urlVars.fixable || Cookies.get('last_fixable');
+  urlVars.errorId = urlVars.errorId || Cookies.get('error_id');
 
   const layers = [];
   $.each(mapBases, (name, layer) => {

--- a/web/static/map/map.js
+++ b/web/static/map/map.js
@@ -37,7 +37,6 @@ export function initMap() {
   urlVars.level = urlVars.level || Cookies.get('last_level') || '1';
   urlVars.tags = urlVars.tags || Cookies.get('last_tags');
   urlVars.fixable = urlVars.fixable || Cookies.get('last_fixable');
-  urlVars.marker_uuid = urlVars.marker_uuid || Cookies.get('marker_uuid');
 
   const layers = [];
   $.each(mapBases, (name, layer) => {

--- a/web/static/map/map.js
+++ b/web/static/map/map.js
@@ -37,7 +37,7 @@ export function initMap() {
   urlVars.level = urlVars.level || Cookies.get('last_level') || '1';
   urlVars.tags = urlVars.tags || Cookies.get('last_tags');
   urlVars.fixable = urlVars.fixable || Cookies.get('last_fixable');
-  urlVars.errorId = urlVars.errorId || Cookies.get('error_id');
+  urlVars.marker_uuid = urlVars.marker_uuid || Cookies.get('marker_uuid');
 
   const layers = [];
   $.each(mapBases, (name, layer) => {

--- a/web/views/byuser/byuser.rss.tpl
+++ b/web/views/byuser/byuser.rss.tpl
@@ -42,7 +42,7 @@
 %    level = res["level"]
 %    lat_s = "%.2f" % lat
 %    lon_s = "%.2f" % lon
-%    url = 'http://%s/map/#zoom=16&lat=%s&lon=%s&item=%s&level=%s&marker_uuid=%s' % (website, lat, lon, item, level, res["uuid"])
+%    url = 'http://%s/map/#zoom=16&lat=%s&lon=%s&item=%s&level=%s&issue_uuid=%s' % (website, lat, lon, item, level, res["uuid"])
         <link>{{url}}</link>
         <guid>http://{{website}}/error/{{res['uuid']}}</guid>
     </item>

--- a/web/views/byuser/byuser.rss.tpl
+++ b/web/views/byuser/byuser.rss.tpl
@@ -42,7 +42,7 @@
 %    level = res["level"]
 %    lat_s = "%.2f" % lat
 %    lon_s = "%.2f" % lon
-%    url = 'http://%s/map/#zoom=16&lat=%s&lon=%s&item=%s&level=%s' % (website, lat, lon, item, level)
+%    url = 'http://%s/map/#zoom=16&lat=%s&lon=%s&item=%s&level=%s&errorId=%s' % (website, lat, lon, item, level, res["uuid"])
         <link>{{url}}</link>
         <guid>http://{{website}}/error/{{res['uuid']}}</guid>
     </item>

--- a/web/views/byuser/byuser.rss.tpl
+++ b/web/views/byuser/byuser.rss.tpl
@@ -42,7 +42,7 @@
 %    level = res["level"]
 %    lat_s = "%.2f" % lat
 %    lon_s = "%.2f" % lon
-%    url = 'http://%s/map/#zoom=16&lat=%s&lon=%s&item=%s&level=%s&errorId=%s' % (website, lat, lon, item, level, res["uuid"])
+%    url = 'http://%s/map/#zoom=16&lat=%s&lon=%s&item=%s&level=%s&marker_uuid=%s' % (website, lat, lon, item, level, res["uuid"])
         <link>{{url}}</link>
         <guid>http://{{website}}/error/{{res['uuid']}}</guid>
     </item>

--- a/web/views/error/index.tpl
+++ b/web/views/error/index.tpl
@@ -46,7 +46,7 @@
 <tr><td>source</td><td><a target="_blank" href="../errors/?item=xxxx&amp;source={{marker['source_id']}}">{{marker['source_id']}}<a></td></tr>
 <tr><td>item</td><td><a target="_blank" href="../errors/?item={{marker['item']}}">{{marker['item']}}</a></td></tr>
 <tr><td>class</td><td><a target="_blank" href="../errors/?item={{marker['item']}}&amp;class={{marker['class']}}">{{marker['class']}}</a></td></tr>
-<tr><td>lat lon</td><td><a target="_blank" href="../map/?item={{marker['item']}}&amp;zoom=17&amp;lat={{marker['lat']}}&amp;lon={{marker['lon']}}&amp;marker_uuid={{marker['uuid']}}">{{marker['lat']}}&nbsp;{{marker['lon']}}</a></td></tr>
+<tr><td>lat lon</td><td><a target="_blank" href="../map/?item={{marker['item']}}&amp;zoom=17&amp;lat={{marker['lat']}}&amp;lon={{marker['lon']}}&amp;issue_uuid={{marker['uuid']}}">{{marker['lat']}}&nbsp;{{marker['lon']}}</a></td></tr>
 <tr><td>title</td><td>
 %show_html_dict(marker['title'])
 </td></tr>

--- a/web/views/error/index.tpl
+++ b/web/views/error/index.tpl
@@ -46,7 +46,7 @@
 <tr><td>source</td><td><a target="_blank" href="../errors/?item=xxxx&amp;source={{marker['source_id']}}">{{marker['source_id']}}<a></td></tr>
 <tr><td>item</td><td><a target="_blank" href="../errors/?item={{marker['item']}}">{{marker['item']}}</a></td></tr>
 <tr><td>class</td><td><a target="_blank" href="../errors/?item={{marker['item']}}&amp;class={{marker['class']}}">{{marker['class']}}</a></td></tr>
-<tr><td>lat lon</td><td><a target="_blank" href="../map/?item={{marker['item']}}&amp;zoom=17&amp;lat={{marker['lat']}}&amp;lon={{marker['lon']}}&amp;errorId={{marker['uuid']}}">{{marker['lat']}}&nbsp;{{marker['lon']}}</a></td></tr>
+<tr><td>lat lon</td><td><a target="_blank" href="../map/?item={{marker['item']}}&amp;zoom=17&amp;lat={{marker['lat']}}&amp;lon={{marker['lon']}}&amp;marker_uuid={{marker['uuid']}}">{{marker['lat']}}&nbsp;{{marker['lon']}}</a></td></tr>
 <tr><td>title</td><td>
 %show_html_dict(marker['title'])
 </td></tr>

--- a/web/views/error/index.tpl
+++ b/web/views/error/index.tpl
@@ -46,7 +46,7 @@
 <tr><td>source</td><td><a target="_blank" href="../errors/?item=xxxx&amp;source={{marker['source_id']}}">{{marker['source_id']}}<a></td></tr>
 <tr><td>item</td><td><a target="_blank" href="../errors/?item={{marker['item']}}">{{marker['item']}}</a></td></tr>
 <tr><td>class</td><td><a target="_blank" href="../errors/?item={{marker['item']}}&amp;class={{marker['class']}}">{{marker['class']}}</a></td></tr>
-<tr><td>lat lon</td><td><a target="_blank" href="../map/?item={{marker['item']}}&amp;zoom=17&amp;lat={{marker['lat']}}&amp;lon={{marker['lon']}}&amp;issue_uuid={{marker['uuid']}}">{{marker['lat']}}&nbsp;{{marker['lon']}}</a></td></tr>
+<tr><td>lat lon</td><td><a target="_blank" href="../map/?item={{marker['item']}}&amp;zoom=17&amp;lat={{marker['lat']}}&amp;lon={{marker['lon']}}&amp;issue_uuid={{uuid}}">{{marker['lat']}}&nbsp;{{marker['lon']}}</a></td></tr>
 <tr><td>title</td><td>
 %show_html_dict(marker['title'])
 </td></tr>

--- a/web/views/error/index.tpl
+++ b/web/views/error/index.tpl
@@ -46,7 +46,7 @@
 <tr><td>source</td><td><a target="_blank" href="../errors/?item=xxxx&amp;source={{marker['source_id']}}">{{marker['source_id']}}<a></td></tr>
 <tr><td>item</td><td><a target="_blank" href="../errors/?item={{marker['item']}}">{{marker['item']}}</a></td></tr>
 <tr><td>class</td><td><a target="_blank" href="../errors/?item={{marker['item']}}&amp;class={{marker['class']}}">{{marker['class']}}</a></td></tr>
-<tr><td>lat lon</td><td><a target="_blank" href="../map/?item={{marker['item']}}&amp;zoom=17&amp;lat={{marker['lat']}}&amp;lon={{marker['lon']}}">{{marker['lat']}}&nbsp;{{marker['lon']}}</a></td></tr>
+<tr><td>lat lon</td><td><a target="_blank" href="../map/?item={{marker['item']}}&amp;zoom=17&amp;lat={{marker['lat']}}&amp;lon={{marker['lon']}}&amp;errorId={{marker['uuid']}}">{{marker['lat']}}&nbsp;{{marker['lon']}}</a></td></tr>
 <tr><td>title</td><td>
 %show_html_dict(marker['title'])
 </td></tr>

--- a/web/views/errors/list.gpx
+++ b/web/views/errors/list.gpx
@@ -62,7 +62,7 @@ http://www.topografix.com/GPX/1/0/gpx.xsd">
       http://localhost:8111/load_and_zoom?left={{minlon}}&amp;bottom={{minlat}}&amp;right={{maxlon}}&amp;top={{maxlat}}
 %    end
     </desc>
-    <url>http://{{website}}/{{lang}}/map/#{{query}}&amp;zoom=16&amp;lat={{lat}}&amp;lon={{lon}}&amp;level={{res["level"]}}&amp;tags=&amp;fixable=&amp;errorId={{res["uuid"]}}</url>
+    <url>http://{{website}}/{{lang}}/map/#{{query}}&amp;zoom=16&amp;lat={{lat}}&amp;lon={{lon}}&amp;level={{res["level"]}}&amp;tags=&amp;fixable=&amp;marker_uuid={{res["uuid"]}}</url>
 </wpt>
 %end
 %end

--- a/web/views/errors/list.gpx
+++ b/web/views/errors/list.gpx
@@ -62,7 +62,7 @@ http://www.topografix.com/GPX/1/0/gpx.xsd">
       http://localhost:8111/load_and_zoom?left={{minlon}}&amp;bottom={{minlat}}&amp;right={{maxlon}}&amp;top={{maxlat}}
 %    end
     </desc>
-    <url>http://{{website}}/{{lang}}/map/#{{query}}&amp;zoom=16&amp;lat={{lat}}&amp;lon={{lon}}&amp;level={{res["level"]}}&amp;tags=&amp;fixable=&amp;marker_uuid={{res["uuid"]}}</url>
+    <url>http://{{website}}/{{lang}}/map/#{{query}}&amp;zoom=16&amp;lat={{lat}}&amp;lon={{lon}}&amp;level={{res["level"]}}&amp;tags=&amp;fixable=&amp;issue_uuid={{res["uuid"]}}</url>
 </wpt>
 %end
 %end

--- a/web/views/errors/list.gpx
+++ b/web/views/errors/list.gpx
@@ -62,7 +62,7 @@ http://www.topografix.com/GPX/1/0/gpx.xsd">
       http://localhost:8111/load_and_zoom?left={{minlon}}&amp;bottom={{minlat}}&amp;right={{maxlon}}&amp;top={{maxlat}}
 %    end
     </desc>
-    <url>http://{{website}}/{{lang}}/map/#{{query}}&amp;zoom=13&amp;lat={{lat}}&amp;lon={{lon}}&amp;level={{res["level"]}}&amp;tags=&amp;fixable=</url>
+    <url>http://{{website}}/{{lang}}/map/#{{query}}&amp;zoom=13&amp;lat={{lat}}&amp;lon={{lon}}&amp;level={{res["level"]}}&amp;tags=&amp;fixable=&amp;errorId={{res["uuid"]}}</url>
 </wpt>
 %end
 %end

--- a/web/views/errors/list.gpx
+++ b/web/views/errors/list.gpx
@@ -62,7 +62,7 @@ http://www.topografix.com/GPX/1/0/gpx.xsd">
       http://localhost:8111/load_and_zoom?left={{minlon}}&amp;bottom={{minlat}}&amp;right={{maxlon}}&amp;top={{maxlat}}
 %    end
     </desc>
-    <url>http://{{website}}/{{lang}}/map/#{{query}}&amp;zoom=13&amp;lat={{lat}}&amp;lon={{lon}}&amp;level={{res["level"]}}&amp;tags=&amp;fixable=&amp;errorId={{res["uuid"]}}</url>
+    <url>http://{{website}}/{{lang}}/map/#{{query}}&amp;zoom=16&amp;lat={{lat}}&amp;lon={{lon}}&amp;level={{res["level"]}}&amp;tags=&amp;fixable=&amp;errorId={{res["uuid"]}}</url>
 </wpt>
 %end
 %end

--- a/web/views/errors/list.kml
+++ b/web/views/errors/list.kml
@@ -34,7 +34,7 @@
 {{translate.select(res["title"])}}\\
 %    end
 </name>
-    <url>http://{{website}}/{{lang}}/map/#{{query}}&amp;zoom=13&amp;lat={{lat}}&amp;lon={{lon}}&amp;level={{res["level"]}}&amp;tags=&amp;fixable=&amp;errorId={{res["uuid"]}}</url>
+    <url>http://{{website}}/{{lang}}/map/#{{query}}&amp;zoom=16&amp;lat={{lat}}&amp;lon={{lon}}&amp;level={{res["level"]}}&amp;tags=&amp;fixable=&amp;errorId={{res["uuid"]}}</url>
     <description>\\
 %    if res["menu"]:
 {{translate.select(res["menu"])}} - \\

--- a/web/views/errors/list.kml
+++ b/web/views/errors/list.kml
@@ -34,7 +34,7 @@
 {{translate.select(res["title"])}}\\
 %    end
 </name>
-    <url>http://{{website}}/{{lang}}/map/#{{query}}&amp;zoom=13&amp;lat={{lat}}&amp;lon={{lon}}&amp;level={{res["level"]}}&amp;tags=&amp;fixable=</url>
+    <url>http://{{website}}/{{lang}}/map/#{{query}}&amp;zoom=13&amp;lat={{lat}}&amp;lon={{lon}}&amp;level={{res["level"]}}&amp;tags=&amp;fixable=&amp;errorId={{res["uuid"]}}</url>
     <description>\\
 %    if res["menu"]:
 {{translate.select(res["menu"])}} - \\

--- a/web/views/errors/list.kml
+++ b/web/views/errors/list.kml
@@ -34,7 +34,7 @@
 {{translate.select(res["title"])}}\\
 %    end
 </name>
-    <url>http://{{website}}/{{lang}}/map/#{{query}}&amp;zoom=16&amp;lat={{lat}}&amp;lon={{lon}}&amp;level={{res["level"]}}&amp;tags=&amp;fixable=&amp;errorId={{res["uuid"]}}</url>
+    <url>http://{{website}}/{{lang}}/map/#{{query}}&amp;zoom=16&amp;lat={{lat}}&amp;lon={{lon}}&amp;level={{res["level"]}}&amp;tags=&amp;fixable=&amp;marker_uuid={{res["uuid"]}}</url>
     <description>\\
 %    if res["menu"]:
 {{translate.select(res["menu"])}} - \\

--- a/web/views/errors/list.kml
+++ b/web/views/errors/list.kml
@@ -34,7 +34,7 @@
 {{translate.select(res["title"])}}\\
 %    end
 </name>
-    <url>http://{{website}}/{{lang}}/map/#{{query}}&amp;zoom=16&amp;lat={{lat}}&amp;lon={{lon}}&amp;level={{res["level"]}}&amp;tags=&amp;fixable=&amp;marker_uuid={{res["uuid"]}}</url>
+    <url>http://{{website}}/{{lang}}/map/#{{query}}&amp;zoom=16&amp;lat={{lat}}&amp;lon={{lon}}&amp;level={{res["level"]}}&amp;tags=&amp;fixable=&amp;issue_uuid={{res["uuid"]}}</url>
     <description>\\
 %    if res["menu"]:
 {{translate.select(res["menu"])}} - \\

--- a/web/views/errors/list.rss
+++ b/web/views/errors/list.rss
@@ -61,7 +61,7 @@
 %    end
     </description>
     <category>{{res["item"]}}</category>
-%    url = 'http://%s/%s/map/#%szoom=16&lat=%s&lon=%s&level=%s&tags=&fixable=&errorId=%s' % (website, lang, query, lat, lon, res["level"], res["uuid"])
+%    url = 'http://%s/%s/map/#%szoom=16&lat=%s&lon=%s&level=%s&tags=&fixable=&marker_uuid=%s' % (website, lang, query, lat, lon, res["level"], res["uuid"])
     <link>{{url}}</link>
     <guid>http://{{website}}/{{lang}}/error/{{res['uuid']}}</guid>
 </item>

--- a/web/views/errors/list.rss
+++ b/web/views/errors/list.rss
@@ -61,7 +61,7 @@
 %    end
     </description>
     <category>{{res["item"]}}</category>
-%    url = 'http://%s/%s/map/#zoom=13&lat=%s&lon=%s&level=%s&tags=&fixable=&errorId=%s' % (website, lang, lat, lon, res["level"], res["uuid"])
+%    url = 'http://%s/%s/map/#zoom=16&lat=%s&lon=%s&level=%s&tags=&fixable=&errorId=%s' % (website, lang, lat, lon, res["level"], res["uuid"])
     <link>{{url}}</link>
     <guid>http://{{website}}/{{lang}}/error/{{res['uuid']}}</guid>
 </item>

--- a/web/views/errors/list.rss
+++ b/web/views/errors/list.rss
@@ -61,7 +61,7 @@
 %    end
     </description>
     <category>{{res["item"]}}</category>
-%    url = 'http://%s/%s/map/#%s&zoom=13&lat=%s&lon=%s&level=%s&tags=&fixable=' % (website, lang, query, lat, lon, res["level"])
+%    url = 'http://%s/%s/map/#zoom=13&lat=%s&lon=%s&level=%s&tags=&fixable=&errorId=%s' % (website, lang, lat, lon, res["level"], res["uuid"])
     <link>{{url}}</link>
     <guid>http://{{website}}/{{lang}}/error/{{res['uuid']}}</guid>
 </item>

--- a/web/views/errors/list.rss
+++ b/web/views/errors/list.rss
@@ -61,7 +61,7 @@
 %    end
     </description>
     <category>{{res["item"]}}</category>
-%    url = 'http://%s/%s/map/#zoom=16&lat=%s&lon=%s&level=%s&tags=&fixable=&errorId=%s' % (website, lang, lat, lon, res["level"], res["uuid"])
+%    url = 'http://%s/%s/map/#%szoom=16&lat=%s&lon=%s&level=%s&tags=&fixable=&errorId=%s' % (website, lang, query, lat, lon, res["level"], res["uuid"])
     <link>{{url}}</link>
     <guid>http://{{website}}/{{lang}}/error/{{res['uuid']}}</guid>
 </item>

--- a/web/views/errors/list.rss
+++ b/web/views/errors/list.rss
@@ -61,7 +61,7 @@
 %    end
     </description>
     <category>{{res["item"]}}</category>
-%    url = 'http://%s/%s/map/#%szoom=16&lat=%s&lon=%s&level=%s&tags=&fixable=&marker_uuid=%s' % (website, lang, query, lat, lon, res["level"], res["uuid"])
+%    url = 'http://%s/%s/map/#%szoom=16&lat=%s&lon=%s&level=%s&tags=&fixable=&issue_uuid=%s' % (website, lang, query, lat, lon, res["level"], res["uuid"])
     <link>{{url}}</link>
     <guid>http://{{website}}/{{lang}}/error/{{res['uuid']}}</guid>
 </item>

--- a/web/views/errors/list.tpl
+++ b/web/views/errors/list.tpl
@@ -42,7 +42,7 @@
 %        lon = res["lon"]
 %        lat_s = "%.2f" % lat
 %        lon_s = "%.2f" % lon
-    <td><a href="/map/#{{query}}&amp;item={{res["item"]}}&amp;zoom=17&amp;lat={{lat}}&amp;lon={{lon}}&amp;level={{res["level"]}}&tags=&fixable=&marker_uuid={{res["uuid"]}}">{{lon_s}}&nbsp;{{lat_s}}</a></td>
+    <td><a href="/map/#{{query}}&amp;item={{res["item"]}}&amp;zoom=17&amp;lat={{lat}}&amp;lon={{lon}}&amp;level={{res["level"]}}&tags=&fixable=&issue_uuid={{res["uuid"]}}">{{lon_s}}&nbsp;{{lat_s}}</a></td>
 %    else:
     <td></td>
 %    end

--- a/web/views/errors/list.tpl
+++ b/web/views/errors/list.tpl
@@ -42,7 +42,7 @@
 %        lon = res["lon"]
 %        lat_s = "%.2f" % lat
 %        lon_s = "%.2f" % lon
-    <td><a href="/map/#{{query}}&amp;item={{res["item"]}}&amp;zoom=17&amp;lat={{lat}}&amp;lon={{lon}}&amp;level={{res["level"]}}&tags=&fixable=">{{lon_s}}&nbsp;{{lat_s}}</a></td>
+    <td><a href="/map/#{{query}}&amp;item={{res["item"]}}&amp;zoom=17&amp;lat={{lat}}&amp;lon={{lon}}&amp;level={{res["level"]}}&tags=&fixable=&errorId={{res["uuid"]}}">{{lon_s}}&nbsp;{{lat_s}}</a></td>
 %    else:
     <td></td>
 %    end

--- a/web/views/errors/list.tpl
+++ b/web/views/errors/list.tpl
@@ -42,7 +42,7 @@
 %        lon = res["lon"]
 %        lat_s = "%.2f" % lat
 %        lon_s = "%.2f" % lon
-    <td><a href="/map/#{{query}}&amp;item={{res["item"]}}&amp;zoom=17&amp;lat={{lat}}&amp;lon={{lon}}&amp;level={{res["level"]}}&tags=&fixable=&errorId={{res["uuid"]}}">{{lon_s}}&nbsp;{{lat_s}}</a></td>
+    <td><a href="/map/#{{query}}&amp;item={{res["item"]}}&amp;zoom=17&amp;lat={{lat}}&amp;lon={{lon}}&amp;level={{res["level"]}}&tags=&fixable=&marker_uuid={{res["uuid"]}}">{{lon_s}}&nbsp;{{lat_s}}</a></td>
 %    else:
     <td></td>
 %    end


### PR DESCRIPTION
Following [this comment](https://github.com/osm-fr/osmose-frontend/issues/155#issuecomment-517908455) on #155.

I added a parameter in the RSS feeds and error lists to allow opening the choosen issue popup on the map from RSS feeds (item link), error lists (`pos` column), GPX etc.

Currently it opens based on the center coordinates of the viewport. It works well when coming from generated links as the viewport is centered on the issue. However if the user pans the map and share its link the popup will not match the error coords, but the center of the viewport. If anyone find how to do so feel free to push to my branch.

But even with this slight bug it improves the editing workflow (it helps a lot in my case) so I think it could be merged.