### PR TITLE
Enforce username in the query string (byuser page)

### DIFF
--- a/web/src/pages/byuser/byuser.vue
+++ b/web/src/pages/byuser/byuser.vue
@@ -18,7 +18,7 @@
             <li class="nav-item">
               <router-link
                 class="nav-link"
-                :to="`../map/#${query}`"
+                :to="nav_link"
               >
                 <translate>Map</translate>
               </router-link>
@@ -76,10 +76,16 @@ export default VueParent.extend({
       count: 0,
       errors: [],
       main_website: "",
+      query: ""
     };
   },
   computed: {
     api_url_path: () => API_URL + window.location.pathname,
+    nav_link() {
+      const params = new URLSearchParams(this.query)
+      params.set("username", this.username)
+      return `../map/#${params.toString()}`
+    }
   },
   components: {
     IssuesList,


### PR DESCRIPTION
Regarding #331 and https://github.com/osm-fr/osmose-frontend/commit/8f1fcbc10d51be79acd073fff87b68f097533b9f

If you remove the `username=${username}` from the query string, you may miss the user param. Since you're at byuser page, the link should have always this param.