### PR TITLE
Expand wikidata secondary keys

### DIFF
--- a/api/tool/tag2link_sources.xml
+++ b/api/tool/tag2link_sources.xml
@@ -60,7 +60,6 @@
             <link name="View %name% article" href="https://%k.1:v.1:en%.wikipedia.org/wiki/%v.2:v.1%" />
         </rule>
         <rule>
-            <condition k="(operator:|network:|brand:|architect:|artist:|subject:|name:etymology:)?wikidata" />
             <link name="View Wikidata page" href="https://www.wikidata.org/wiki/%v%" />
         </rule>
         <rule>

--- a/api/tool/tag2link_sources.xml
+++ b/api/tool/tag2link_sources.xml
@@ -60,6 +60,7 @@
             <link name="View %name% article" href="https://%k.1:v.1:en%.wikipedia.org/wiki/%v.2:v.1%" />
         </rule>
         <rule>
+            <condition k="(operator:|network:|brand:|architect:|artist:|subject:|name:etymology:|species:|genus:|flag:|buried:)?wikidata" />
             <link name="View Wikidata page" href="https://www.wikidata.org/wiki/%v%" />
         </rule>
         <rule>


### PR DESCRIPTION
Hi @frodrigo 

The `species:|genus:|flag:|buried` secondary tags are also widely used, so having links would help.

Sources:
- https://wiki.openstreetmap.org/wiki/Key:wikidata#Secondary_Wikidata_links
- https://taginfo.openstreetmap.org/search?q=species%3Awikidata