### PR TITLE
Fix English typos

### DIFF
--- a/web/po/Makefile
+++ b/web/po/Makefile
@@ -35,7 +35,7 @@ osmose-frontend.pot: python.pot vue.pot
 	rm $@.nofiles
 
 %.po:
-	tx pull -a --minimum-perc=10
+	tx pull -a --minimum-perc=5
 
 mo: $(MO)
 

--- a/web/po/ca.po
+++ b/web/po/ca.po
@@ -10,14 +10,15 @@
 # jmontane, 2015
 # Joan Montané, 2015
 # Joan Montané, 2015
+# Joan Montané, 2015
 msgid ""
 msgstr ""
 "Project-Id-Version: Osmose\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2014-03-18 22:25+0100\n"
 "PO-Revision-Date: 2014-04-28 19:22+0000\n"
-"Last-Translator: Hugoren Martinako <aumpfbahn@gmail.com>, 2020\n"
-"Language-Team: Catalan (http://www.transifex.com/openstreetmap-france/osmose/language/ca/)\n"
+"Last-Translator: Joan Montané, 2015\n"
+"Language-Team: Catalan (http://app.transifex.com/openstreetmap-france/osmose/language/ca/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -820,7 +821,7 @@ msgid "gas station"
 msgstr "gasolinera"
 
 #: ../src/pages/map/editor.vue:4
-msgid "You must be logged in order to use the tag editor"
+msgid "You must be logged in to use the tag editor"
 msgstr "Heu de tenir sessió iniciada per a poder usar l'editor d'etiquetes"
 
 #: ../src/pages/map/editor-modal.vue:2
@@ -1225,14 +1226,14 @@ msgstr ""
 
 #: ../src/pages/map/popup.vue ../src/pages/map/popup.vue:388
 msgid ""
-"Report the issue as improper, if according to you is not an issue. The issue"
-" will not be displayed to anyone more."
+"Report the issue as improper, if it is not an issue according to you. The "
+"issue will not be displayed to anyone anymore."
 msgstr ""
 
 #: ../src/pages/map/popup.vue:402
 msgid ""
-"After issue fixed on the OSM data, mark it as done. May also disappear "
-"automatically on next check if no more issue."
+"After fixing the issue in the OSM data, mark it as done. It will also "
+"disappear automatically on the next check."
 msgstr ""
 
 #: ../../tools/database/items_menu.txt:44
@@ -1588,7 +1589,7 @@ msgstr ""
 #: ../src/pages/byuser/byuser.vue:45
 msgid ""
 "This page shows issues on elements that were last modified by '{users}'. "
-"This doesn't means that this user is responsible for all these issues."
+"This doesn't mean that this user is responsible for all these issues."
 msgstr ""
 
 #: ../src/pages/byuser/byuser.vue:7

--- a/web/po/cs.po
+++ b/web/po/cs.po
@@ -5,20 +5,21 @@
 # Translators:
 # Jakub Jelen <jakuje@gmail.com>, 2020
 # Jan Vršovský <vrs@email.cz>, 2015
-# trendspotter <jirka.p@volny.cz>, 2018
-# trendspotter <jirka.p@volny.cz>, 2019
+# Jiří Podhorecký, 2018
+# Jiří Podhorecký, 2019
 # Michal Pustějovský <Michal.Pustejovsky@seznam.cz>, 2014
 # Petr Schönmann <pschonmann@gmail.com>, 2014,2018
 # TK, 2014-2015,2017,2020
-# trendspotter <jirka.p@volny.cz>, 2018-2019
+# Jiří Podhorecký, 2018-2019
+# Jiří Podhorecký, 2018-2019
 msgid ""
 msgstr ""
 "Project-Id-Version: Osmose\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2014-03-18 22:25+0100\n"
 "PO-Revision-Date: 2014-04-28 19:22+0000\n"
-"Last-Translator: Jakub Jelen <jakuje@gmail.com>, 2020\n"
-"Language-Team: Czech (http://www.transifex.com/openstreetmap-france/osmose/language/cs/)\n"
+"Last-Translator: Petr Schönmann <pschonmann@gmail.com>, 2014,2018\n"
+"Language-Team: Czech (http://app.transifex.com/openstreetmap-france/osmose/language/cs/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -821,7 +822,7 @@ msgid "gas station"
 msgstr "čerpací stanice"
 
 #: ../src/pages/map/editor.vue:4
-msgid "You must be logged in order to use the tag editor"
+msgid "You must be logged in to use the tag editor"
 msgstr "K použití editoru klíčů musíte být přihlášení."
 
 #: ../src/pages/map/editor-modal.vue:2
@@ -1226,14 +1227,14 @@ msgstr "Záležitost nahlášena v:"
 
 #: ../src/pages/map/popup.vue ../src/pages/map/popup.vue:388
 msgid ""
-"Report the issue as improper, if according to you is not an issue. The issue"
-" will not be displayed to anyone more."
+"Report the issue as improper, if it is not an issue according to you. The "
+"issue will not be displayed to anyone anymore."
 msgstr "Nahlásit problém jako nevhodný, pokud to podle vás není problém. Problém se nikomu dalšímu nezobrazí."
 
 #: ../src/pages/map/popup.vue:402
 msgid ""
-"After issue fixed on the OSM data, mark it as done. May also disappear "
-"automatically on next check if no more issue."
+"After fixing the issue in the OSM data, mark it as done. It will also "
+"disappear automatically on the next check."
 msgstr "Po vyřešení problému na základě údajů OSM označte jej jako hotový. Může také zmizet automaticky při příští kontrole, pokud to již není problém."
 
 #: ../../tools/database/items_menu.txt:44
@@ -1589,7 +1590,7 @@ msgstr ""
 #: ../src/pages/byuser/byuser.vue:45
 msgid ""
 "This page shows issues on elements that were last modified by '{users}'. "
-"This doesn't means that this user is responsible for all these issues."
+"This doesn't mean that this user is responsible for all these issues."
 msgstr ""
 
 #: ../src/pages/byuser/byuser.vue:7

--- a/web/po/da.po
+++ b/web/po/da.po
@@ -13,7 +13,7 @@ msgstr ""
 "POT-Creation-Date: 2014-03-18 22:25+0100\n"
 "PO-Revision-Date: 2014-04-28 19:22+0000\n"
 "Last-Translator: Neogeografen <soren.johannessen@gmail.com>, 2014\n"
-"Language-Team: Danish (http://www.transifex.com/openstreetmap-france/osmose/language/da/)\n"
+"Language-Team: Danish (http://app.transifex.com/openstreetmap-france/osmose/language/da/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -816,7 +816,7 @@ msgid "gas station"
 msgstr "tankstation"
 
 #: ../src/pages/map/editor.vue:4
-msgid "You must be logged in order to use the tag editor"
+msgid "You must be logged in to use the tag editor"
 msgstr "Du skal være logget ind for at kunne bruge tag editoren"
 
 #: ../src/pages/map/editor-modal.vue:2
@@ -1221,14 +1221,14 @@ msgstr ""
 
 #: ../src/pages/map/popup.vue ../src/pages/map/popup.vue:388
 msgid ""
-"Report the issue as improper, if according to you is not an issue. The issue"
-" will not be displayed to anyone more."
+"Report the issue as improper, if it is not an issue according to you. The "
+"issue will not be displayed to anyone anymore."
 msgstr ""
 
 #: ../src/pages/map/popup.vue:402
 msgid ""
-"After issue fixed on the OSM data, mark it as done. May also disappear "
-"automatically on next check if no more issue."
+"After fixing the issue in the OSM data, mark it as done. It will also "
+"disappear automatically on the next check."
 msgstr ""
 
 #: ../../tools/database/items_menu.txt:44
@@ -1584,7 +1584,7 @@ msgstr ""
 #: ../src/pages/byuser/byuser.vue:45
 msgid ""
 "This page shows issues on elements that were last modified by '{users}'. "
-"This doesn't means that this user is responsible for all these issues."
+"This doesn't mean that this user is responsible for all these issues."
 msgstr ""
 
 #: ../src/pages/byuser/byuser.vue:7

--- a/web/po/de.po
+++ b/web/po/de.po
@@ -4,6 +4,7 @@
 # 
 # Translators:
 # Bamstam, 2020
+# Bamstam, 2020
 # Christian Ostermann, 2015
 # Christian Ostermann, 2015
 # Christian Ostermann, 2017-2019
@@ -17,6 +18,7 @@
 # kjon kjon <kjon@gmx.de>, 2020,2022-2023
 # Klumbumbus, 2015
 # Loo Nie <looniverse@gmail.com>, 2015
+# Lukas Sommer, 2014
 # Manfred Brandl <manfred@brandl.net>, 2020-2022
 # operon, 2012
 # operon, 2012
@@ -30,6 +32,7 @@
 # Lukas Sommer, 2014
 # Lukas Sommer, 2014
 # Tim D., 2022
+# Tim D., 2022
 # ToniE <osm-ToniE@web.de>, 2020
 # xuiqzy xuiqzy <pirminbraun16@gmail.com>, 2019
 msgid ""
@@ -38,8 +41,8 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2014-03-18 22:25+0100\n"
 "PO-Revision-Date: 2014-04-28 19:22+0000\n"
-"Last-Translator: kjon kjon <kjon@gmx.de>, 2020,2022-2023\n"
-"Language-Team: German (http://www.transifex.com/openstreetmap-france/osmose/language/de/)\n"
+"Last-Translator: xuiqzy xuiqzy <pirminbraun16@gmail.com>, 2019\n"
+"Language-Team: German (http://app.transifex.com/openstreetmap-france/osmose/language/de/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -842,7 +845,7 @@ msgid "gas station"
 msgstr "Tankstelle"
 
 #: ../src/pages/map/editor.vue:4
-msgid "You must be logged in order to use the tag editor"
+msgid "You must be logged in to use the tag editor"
 msgstr "Du musst eingeloggt sein um den Tag-Editor zu benutzen"
 
 #: ../src/pages/map/editor-modal.vue:2
@@ -1247,14 +1250,14 @@ msgstr "Problem gemeldet am:"
 
 #: ../src/pages/map/popup.vue ../src/pages/map/popup.vue:388
 msgid ""
-"Report the issue as improper, if according to you is not an issue. The issue"
-" will not be displayed to anyone more."
+"Report the issue as improper, if it is not an issue according to you. The "
+"issue will not be displayed to anyone anymore."
 msgstr "Melde das Problem als Falschmeldung, wenn es nach deiner Meinung keines ist. Das Problem wird niemandem mehr angezeigt."
 
 #: ../src/pages/map/popup.vue:402
 msgid ""
-"After issue fixed on the OSM data, mark it as done. May also disappear "
-"automatically on next check if no more issue."
+"After fixing the issue in the OSM data, mark it as done. It will also "
+"disappear automatically on the next check."
 msgstr "Nachdem das Problem in den OSM-Daten behoben wurden, markiere es als behoben. Er wird auch automatisch entfernt, wenn das Problem bei der nächsten Überprüfung nicht mehr vorhanden ist."
 
 #: ../../tools/database/items_menu.txt:44
@@ -1610,7 +1613,7 @@ msgstr "Statistik für Benutzer {user}"
 #: ../src/pages/byuser/byuser.vue:45
 msgid ""
 "This page shows issues on elements that were last modified by '{users}'. "
-"This doesn't means that this user is responsible for all these issues."
+"This doesn't mean that this user is responsible for all these issues."
 msgstr "Diese Seite zeigt Probleme mit Elementen, die zuletzt von '{users}' geändert wurden. Das bedeutet nicht, dass dieser Benutzer für alle diese Probleme verantwortlich ist."
 
 #: ../src/pages/byuser/byuser.vue:7
@@ -1837,8 +1840,8 @@ msgstr "Bürgersteig"
 
 #: ../../web_api/byuser.py:96
 msgid "Statistics for user {}"
-msgstr ""
+msgstr "Statistik für Nutzer {}"
 
 #: ../src/pages/issues/index.vue:279
 msgid "{{ showAnalyserCount }} / {{ errors_groups.length }} rows. Show more."
-msgstr ""
+msgstr "{{ showAnalyserCount }} / {{ errors_groups.length }} Reihen. Mehr anzeigen."

--- a/web/po/el.po
+++ b/web/po/el.po
@@ -12,8 +12,8 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2014-03-18 22:25+0100\n"
 "PO-Revision-Date: 2014-04-28 19:22+0000\n"
-"Last-Translator: Jim Kats <jim-kats@hotmail.com>, 2022\n"
-"Language-Team: Greek (http://www.transifex.com/openstreetmap-france/osmose/language/el/)\n"
+"Last-Translator: Yannis Gyftomitros, 2014\n"
+"Language-Team: Greek (http://app.transifex.com/openstreetmap-france/osmose/language/el/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -816,7 +816,7 @@ msgid "gas station"
 msgstr "βενζινάδικο"
 
 #: ../src/pages/map/editor.vue:4
-msgid "You must be logged in order to use the tag editor"
+msgid "You must be logged in to use the tag editor"
 msgstr "Πρέπει να είστε συνδεδεμένος για να μπορέσετε να χρησιμοποιήσετε τον επεξεργαστή ετικετών"
 
 #: ../src/pages/map/editor-modal.vue:2
@@ -1221,14 +1221,14 @@ msgstr ""
 
 #: ../src/pages/map/popup.vue ../src/pages/map/popup.vue:388
 msgid ""
-"Report the issue as improper, if according to you is not an issue. The issue"
-" will not be displayed to anyone more."
+"Report the issue as improper, if it is not an issue according to you. The "
+"issue will not be displayed to anyone anymore."
 msgstr ""
 
 #: ../src/pages/map/popup.vue:402
 msgid ""
-"After issue fixed on the OSM data, mark it as done. May also disappear "
-"automatically on next check if no more issue."
+"After fixing the issue in the OSM data, mark it as done. It will also "
+"disappear automatically on the next check."
 msgstr ""
 
 #: ../../tools/database/items_menu.txt:44
@@ -1584,7 +1584,7 @@ msgstr ""
 #: ../src/pages/byuser/byuser.vue:45
 msgid ""
 "This page shows issues on elements that were last modified by '{users}'. "
-"This doesn't means that this user is responsible for all these issues."
+"This doesn't mean that this user is responsible for all these issues."
 msgstr ""
 
 #: ../src/pages/byuser/byuser.vue:7

--- a/web/po/es.po
+++ b/web/po/es.po
@@ -3,6 +3,7 @@
 # This file is distributed under the same license as the osmose-frontend package.
 # 
 # Translators:
+# 3c4f354c26c2c190ba28f9c2666d7fdb_003e9d1 <b28923423b98dace80389ae64c99bf93_129697>, 2014
 # emilio asensi <viciaodynastywarriors@gmail.com>, 2021
 # Franco, 2018
 # Franco, 2018
@@ -11,8 +12,10 @@
 # Hugoren Martinako <aumpfbahn@gmail.com>, 2020-2021
 # Jorge Sanz <sanchi2@gmail.com>, 2019-2022
 # Juan Carlos, 2020
+# Juan Carlos, 2020
 # 3c4f354c26c2c190ba28f9c2666d7fdb_003e9d1 <b28923423b98dace80389ae64c99bf93_129697>, 2014
 # 3c4f354c26c2c190ba28f9c2666d7fdb_003e9d1 <b28923423b98dace80389ae64c99bf93_129697>, 2014-2017,2020
+# Mikel Ortega, 2020,2022
 # Mikel Ortega, 2020,2022
 msgid ""
 msgstr ""
@@ -21,7 +24,7 @@ msgstr ""
 "POT-Creation-Date: 2014-03-18 22:25+0100\n"
 "PO-Revision-Date: 2014-04-28 19:22+0000\n"
 "Last-Translator: Mikel Ortega, 2020,2022\n"
-"Language-Team: Spanish (http://www.transifex.com/openstreetmap-france/osmose/language/es/)\n"
+"Language-Team: Spanish (http://app.transifex.com/openstreetmap-france/osmose/language/es/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -824,7 +827,7 @@ msgid "gas station"
 msgstr "gasolinera"
 
 #: ../src/pages/map/editor.vue:4
-msgid "You must be logged in order to use the tag editor"
+msgid "You must be logged in to use the tag editor"
 msgstr "Debe estar conectado para poder utilizar el editor de etiquetas"
 
 #: ../src/pages/map/editor-modal.vue:2
@@ -1229,14 +1232,14 @@ msgstr "Problema informado el:"
 
 #: ../src/pages/map/popup.vue ../src/pages/map/popup.vue:388
 msgid ""
-"Report the issue as improper, if according to you is not an issue. The issue"
-" will not be displayed to anyone more."
+"Report the issue as improper, if it is not an issue according to you. The "
+"issue will not be displayed to anyone anymore."
 msgstr "Informe el problema como impropio, si según usted no es un problema. El problema no se mostrará a nadie más."
 
 #: ../src/pages/map/popup.vue:402
 msgid ""
-"After issue fixed on the OSM data, mark it as done. May also disappear "
-"automatically on next check if no more issue."
+"After fixing the issue in the OSM data, mark it as done. It will also "
+"disappear automatically on the next check."
 msgstr "Después de solucionar el problema en los datos de OSM, márquelo como hecho. También puede desaparecer automáticamente en la próxima comprobación si no hay más problema."
 
 #: ../../tools/database/items_menu.txt:44
@@ -1592,7 +1595,7 @@ msgstr "Estadísticas para el usuario {user}"
 #: ../src/pages/byuser/byuser.vue:45
 msgid ""
 "This page shows issues on elements that were last modified by '{users}'. "
-"This doesn't means that this user is responsible for all these issues."
+"This doesn't mean that this user is responsible for all these issues."
 msgstr "Esta página muestra los problemas de elementos que fueron modificados por última vez por '{users}'. Esto no significa que este usuario es responsable de todos estos problemas."
 
 #: ../src/pages/byuser/byuser.vue:7

--- a/web/po/eu.po
+++ b/web/po/eu.po
@@ -4,6 +4,7 @@
 # 
 # Translators:
 # Mikel Ortega, 2020
+# Mikel Ortega, 2020
 msgid ""
 msgstr ""
 "Project-Id-Version: Osmose\n"
@@ -11,7 +12,7 @@ msgstr ""
 "POT-Creation-Date: 2014-03-18 22:25+0100\n"
 "PO-Revision-Date: 2014-04-28 19:22+0000\n"
 "Last-Translator: Mikel Ortega, 2020\n"
-"Language-Team: Basque (http://www.transifex.com/openstreetmap-france/osmose/language/eu/)\n"
+"Language-Team: Basque (http://app.transifex.com/openstreetmap-france/osmose/language/eu/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -814,7 +815,7 @@ msgid "gas station"
 msgstr "gasolindegia"
 
 #: ../src/pages/map/editor.vue:4
-msgid "You must be logged in order to use the tag editor"
+msgid "You must be logged in to use the tag editor"
 msgstr ""
 
 #: ../src/pages/map/editor-modal.vue:2
@@ -1219,14 +1220,14 @@ msgstr ""
 
 #: ../src/pages/map/popup.vue ../src/pages/map/popup.vue:388
 msgid ""
-"Report the issue as improper, if according to you is not an issue. The issue"
-" will not be displayed to anyone more."
+"Report the issue as improper, if it is not an issue according to you. The "
+"issue will not be displayed to anyone anymore."
 msgstr ""
 
 #: ../src/pages/map/popup.vue:402
 msgid ""
-"After issue fixed on the OSM data, mark it as done. May also disappear "
-"automatically on next check if no more issue."
+"After fixing the issue in the OSM data, mark it as done. It will also "
+"disappear automatically on the next check."
 msgstr ""
 
 #: ../../tools/database/items_menu.txt:44
@@ -1582,7 +1583,7 @@ msgstr ""
 #: ../src/pages/byuser/byuser.vue:45
 msgid ""
 "This page shows issues on elements that were last modified by '{users}'. "
-"This doesn't means that this user is responsible for all these issues."
+"This doesn't mean that this user is responsible for all these issues."
 msgstr ""
 
 #: ../src/pages/byuser/byuser.vue:7

--- a/web/po/fa.po
+++ b/web/po/fa.po
@@ -11,8 +11,8 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2014-03-18 22:25+0100\n"
 "PO-Revision-Date: 2014-04-28 19:22+0000\n"
-"Last-Translator: imni <iriman@chmail.ir>, 2018-2020\n"
-"Language-Team: Persian (http://www.transifex.com/openstreetmap-france/osmose/language/fa/)\n"
+"Last-Translator: imni <iriman@chmail.ir>, 2018\n"
+"Language-Team: Persian (http://app.transifex.com/openstreetmap-france/osmose/language/fa/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -815,7 +815,7 @@ msgid "gas station"
 msgstr "پمپ بنزین"
 
 #: ../src/pages/map/editor.vue:4
-msgid "You must be logged in order to use the tag editor"
+msgid "You must be logged in to use the tag editor"
 msgstr "برای استفاده از ویرایشگر تگ باید وارد شوید"
 
 #: ../src/pages/map/editor-modal.vue:2
@@ -1220,14 +1220,14 @@ msgstr "تاریخ گزارش:"
 
 #: ../src/pages/map/popup.vue ../src/pages/map/popup.vue:388
 msgid ""
-"Report the issue as improper, if according to you is not an issue. The issue"
-" will not be displayed to anyone more."
+"Report the issue as improper, if it is not an issue according to you. The "
+"issue will not be displayed to anyone anymore."
 msgstr "اگر با ارزیابی خودتان این مورد مشکلی ندارد، گزارش کنید که نابجاست. در نتیجه این مسئله برای کس دیگری نمایش داده نمی‌شود."
 
 #: ../src/pages/map/popup.vue:402
 msgid ""
-"After issue fixed on the OSM data, mark it as done. May also disappear "
-"automatically on next check if no more issue."
+"After fixing the issue in the OSM data, mark it as done. It will also "
+"disappear automatically on the next check."
 msgstr "پس از اینکه مشکل داده‌ها اصلاح شد، آن را در حالت حل‌شده قرار دهید. در بررسی بعدی، اگر مسئلهٔ دیگری نداشته باشد، به‌طور خودکار ناپدید می‌شود."
 
 #: ../../tools/database/items_menu.txt:44
@@ -1583,7 +1583,7 @@ msgstr ""
 #: ../src/pages/byuser/byuser.vue:45
 msgid ""
 "This page shows issues on elements that were last modified by '{users}'. "
-"This doesn't means that this user is responsible for all these issues."
+"This doesn't mean that this user is responsible for all these issues."
 msgstr ""
 
 #: ../src/pages/byuser/byuser.vue:7

--- a/web/po/fi.po
+++ b/web/po/fi.po
@@ -13,7 +13,7 @@ msgstr ""
 "POT-Creation-Date: 2014-03-18 22:25+0100\n"
 "PO-Revision-Date: 2014-04-28 19:22+0000\n"
 "Last-Translator: Jaakko Helleranta <jaakko@helleranta.com>, 2016\n"
-"Language-Team: Finnish (http://www.transifex.com/openstreetmap-france/osmose/language/fi/)\n"
+"Language-Team: Finnish (http://app.transifex.com/openstreetmap-france/osmose/language/fi/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -816,7 +816,7 @@ msgid "gas station"
 msgstr "bensa-asema"
 
 #: ../src/pages/map/editor.vue:4
-msgid "You must be logged in order to use the tag editor"
+msgid "You must be logged in to use the tag editor"
 msgstr ""
 
 #: ../src/pages/map/editor-modal.vue:2
@@ -1221,14 +1221,14 @@ msgstr ""
 
 #: ../src/pages/map/popup.vue ../src/pages/map/popup.vue:388
 msgid ""
-"Report the issue as improper, if according to you is not an issue. The issue"
-" will not be displayed to anyone more."
+"Report the issue as improper, if it is not an issue according to you. The "
+"issue will not be displayed to anyone anymore."
 msgstr ""
 
 #: ../src/pages/map/popup.vue:402
 msgid ""
-"After issue fixed on the OSM data, mark it as done. May also disappear "
-"automatically on next check if no more issue."
+"After fixing the issue in the OSM data, mark it as done. It will also "
+"disappear automatically on the next check."
 msgstr ""
 
 #: ../../tools/database/items_menu.txt:44
@@ -1584,7 +1584,7 @@ msgstr ""
 #: ../src/pages/byuser/byuser.vue:45
 msgid ""
 "This page shows issues on elements that were last modified by '{users}'. "
-"This doesn't means that this user is responsible for all these issues."
+"This doesn't mean that this user is responsible for all these issues."
 msgstr ""
 
 #: ../src/pages/byuser/byuser.vue:7

--- a/web/po/fr.po
+++ b/web/po/fr.po
@@ -4,7 +4,9 @@
 # 
 # Translators:
 # A-d-r-i, 2021
+# A-d-r-i, 2021
 # Adrien Pavie <panieravide@riseup.net>, 2015,2020
+# bagage <gautier.pelloux@gmail.com>, 2018
 # Baptiste Mille-Mathias <baptiste.millemathias@gmail.com>, 2017
 # Binnette <binnette@gmail.com>, 2019
 # Christian Quest <christian.quest@gmail.com>, 2015
@@ -13,6 +15,8 @@
 # Donat ROBAUX <donat.r@gmail.com>, 2021
 # florian lainez <winnerflo@free.fr>, 2021
 # François Magimel, 2020
+# François Magimel, 2020
+# FredB <fredbourgeon@gmail.com>, 2022
 # FredB <fredbourgeon@gmail.com>, 2022
 # frodrigo <fred.rodrigo@gmail.com>, 2014-2021
 # frodrigo <fred.rodrigo@gmail.com>, 2014
@@ -41,6 +45,7 @@
 # Philippe Verdy, 2017-2019,2022
 # Pyrog <pyrog@laposte.net>, 2014
 # Roue Libre, 2020
+# Roue Libre, 2020
 # Sébastien Duthil <duthils@free.fr>, 2015-2016
 # Sidjy <gross.c@gmail.com>, 2015
 # StephaneP <stephane.peneau@wanadoo.fr>, 2016
@@ -54,8 +59,8 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2014-03-18 22:25+0100\n"
 "PO-Revision-Date: 2014-04-28 19:22+0000\n"
-"Last-Translator: Philippe Verdy, 2017-2019,2022\n"
-"Language-Team: French (http://www.transifex.com/openstreetmap-france/osmose/language/fr/)\n"
+"Last-Translator: Philippe Verdy, 2017\n"
+"Language-Team: French (http://app.transifex.com/openstreetmap-france/osmose/language/fr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -858,7 +863,7 @@ msgid "gas station"
 msgstr "station-service"
 
 #: ../src/pages/map/editor.vue:4
-msgid "You must be logged in order to use the tag editor"
+msgid "You must be logged in to use the tag editor"
 msgstr "Vous devez être identifié pour utiliser l’éditeur d’attributs"
 
 #: ../src/pages/map/editor-modal.vue:2
@@ -1263,14 +1268,14 @@ msgstr "Signalement du :"
 
 #: ../src/pages/map/popup.vue ../src/pages/map/popup.vue:388
 msgid ""
-"Report the issue as improper, if according to you is not an issue. The issue"
-" will not be displayed to anyone more."
+"Report the issue as improper, if it is not an issue according to you. The "
+"issue will not be displayed to anyone anymore."
 msgstr "Rapporter le signalement comme invalide, si selon vous ce n'est pas un problème. Le signalement ne sera plus affiché à personne."
 
 #: ../src/pages/map/popup.vue:402
 msgid ""
-"After issue fixed on the OSM data, mark it as done. May also disappear "
-"automatically on next check if no more issue."
+"After fixing the issue in the OSM data, mark it as done. It will also "
+"disappear automatically on the next check."
 msgstr "Après avoir corrigé le signalement dans les données d'OSM, le marquer comme corrigé. Il pourra également disparaître automatiquement au prochain contrôle s'il n'y a plus de problème."
 
 #: ../../tools/database/items_menu.txt:44
@@ -1626,7 +1631,7 @@ msgstr "Statistiques pour l'utilisateur {user}"
 #: ../src/pages/byuser/byuser.vue:45
 msgid ""
 "This page shows issues on elements that were last modified by '{users}'. "
-"This doesn't means that this user is responsible for all these issues."
+"This doesn't mean that this user is responsible for all these issues."
 msgstr "Cette page présente les problèmes relatifs aux éléments qui ont été modifiés en dernier lieu par '{users}'. Cela ne signifie pas que cet utilisateur est responsable de tous ces problèmes."
 
 #: ../src/pages/byuser/byuser.vue:7

--- a/web/po/gl.po
+++ b/web/po/gl.po
@@ -4,6 +4,7 @@
 # 
 # Translators:
 # ccpr1l <csdpe0810-tf@yahoo.es>, 2020
+# ccpr1l <csdpe0810-tf@yahoo.es>, 2020
 # Navhy, 2019
 # Navhy, 2019
 # Navhy, 2019
@@ -13,8 +14,8 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2014-03-18 22:25+0100\n"
 "PO-Revision-Date: 2014-04-28 19:22+0000\n"
-"Last-Translator: ccpr1l <csdpe0810-tf@yahoo.es>, 2020\n"
-"Language-Team: Galician (http://www.transifex.com/openstreetmap-france/osmose/language/gl/)\n"
+"Last-Translator: Navhy, 2019\n"
+"Language-Team: Galician (http://app.transifex.com/openstreetmap-france/osmose/language/gl/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -817,7 +818,7 @@ msgid "gas station"
 msgstr "gasolineira"
 
 #: ../src/pages/map/editor.vue:4
-msgid "You must be logged in order to use the tag editor"
+msgid "You must be logged in to use the tag editor"
 msgstr "Tes que estar conectado para poder empregar o editor de etiquetas"
 
 #: ../src/pages/map/editor-modal.vue:2
@@ -1222,14 +1223,14 @@ msgstr "Problema informado no:"
 
 #: ../src/pages/map/popup.vue ../src/pages/map/popup.vue:388
 msgid ""
-"Report the issue as improper, if according to you is not an issue. The issue"
-" will not be displayed to anyone more."
+"Report the issue as improper, if it is not an issue according to you. The "
+"issue will not be displayed to anyone anymore."
 msgstr "Informa o problema coma non axeitado, se está de acordo contigo non é un problema. O problema non se amosará a ninguén máis."
 
 #: ../src/pages/map/popup.vue:402
 msgid ""
-"After issue fixed on the OSM data, mark it as done. May also disappear "
-"automatically on next check if no more issue."
+"After fixing the issue in the OSM data, mark it as done. It will also "
+"disappear automatically on the next check."
 msgstr "Após solucionar o problema nos datos do OSM, márcao coma feito. Tamén pode desaparecer de xeito automático na seguinte comprobación se non hai máis problema."
 
 #: ../../tools/database/items_menu.txt:44
@@ -1585,7 +1586,7 @@ msgstr ""
 #: ../src/pages/byuser/byuser.vue:45
 msgid ""
 "This page shows issues on elements that were last modified by '{users}'. "
-"This doesn't means that this user is responsible for all these issues."
+"This doesn't mean that this user is responsible for all these issues."
 msgstr ""
 
 #: ../src/pages/byuser/byuser.vue:7

--- a/web/po/hu.po
+++ b/web/po/hu.po
@@ -13,8 +13,8 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2014-03-18 22:25+0100\n"
 "PO-Revision-Date: 2014-04-28 19:22+0000\n"
-"Last-Translator: Gábor Babos <gabor.babos@gmail.com>, 2017-2021\n"
-"Language-Team: Hungarian (http://www.transifex.com/openstreetmap-france/osmose/language/hu/)\n"
+"Last-Translator: nagy_balint <nagy_balint@freemail.hu>, 2014\n"
+"Language-Team: Hungarian (http://app.transifex.com/openstreetmap-france/osmose/language/hu/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -817,7 +817,7 @@ msgid "gas station"
 msgstr "benzinkút"
 
 #: ../src/pages/map/editor.vue:4
-msgid "You must be logged in order to use the tag editor"
+msgid "You must be logged in to use the tag editor"
 msgstr "A címkeszerkesztő használatához be kell lépned"
 
 #: ../src/pages/map/editor-modal.vue:2
@@ -1222,14 +1222,14 @@ msgstr "Hiba jelentésének ideje:"
 
 #: ../src/pages/map/popup.vue ../src/pages/map/popup.vue:388
 msgid ""
-"Report the issue as improper, if according to you is not an issue. The issue"
-" will not be displayed to anyone more."
+"Report the issue as improper, if it is not an issue according to you. The "
+"issue will not be displayed to anyone anymore."
 msgstr "Ha szerinted ez nem hiba, jelöld meg helytelenként. A hiba többé senkinek sem fog megjelenni."
 
 #: ../src/pages/map/popup.vue:402
 msgid ""
-"After issue fixed on the OSM data, mark it as done. May also disappear "
-"automatically on next check if no more issue."
+"After fixing the issue in the OSM data, mark it as done. It will also "
+"disappear automatically on the next check."
 msgstr "Miután a hibát kijavítottad az OSM-adatbázisban, jelöld meg készként. Automatikusan is eltűnhet a következő ellenőrzéskor, ha már nincs benne hiba."
 
 #: ../../tools/database/items_menu.txt:44
@@ -1585,7 +1585,7 @@ msgstr "{user} felhasználó statisztikája"
 #: ../src/pages/byuser/byuser.vue:45
 msgid ""
 "This page shows issues on elements that were last modified by '{users}'. "
-"This doesn't means that this user is responsible for all these issues."
+"This doesn't mean that this user is responsible for all these issues."
 msgstr "Ez az oldal azon elemek lehetséges hibáit jeleníti meg, amelyeket utoljára '{users}' módosított. Ez nem jelenti azt, hogy ez a felhasználó lenne a felelő mindezen hibákért."
 
 #: ../src/pages/byuser/byuser.vue:7

--- a/web/po/it.po
+++ b/web/po/it.po
@@ -22,8 +22,8 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2014-03-18 22:25+0100\n"
 "PO-Revision-Date: 2014-04-28 19:22+0000\n"
-"Last-Translator: Andrea Musuruane <musuruan@gmail.com>, 2022\n"
-"Language-Team: Italian (http://www.transifex.com/openstreetmap-france/osmose/language/it/)\n"
+"Last-Translator: operon, 2012\n"
+"Language-Team: Italian (http://app.transifex.com/openstreetmap-france/osmose/language/it/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -826,7 +826,7 @@ msgid "gas station"
 msgstr "stazione di rifornimento"
 
 #: ../src/pages/map/editor.vue:4
-msgid "You must be logged in order to use the tag editor"
+msgid "You must be logged in to use the tag editor"
 msgstr "Devi essere loggato per usare l'editor dei tag"
 
 #: ../src/pages/map/editor-modal.vue:2
@@ -1231,14 +1231,14 @@ msgstr "Errore segnalato il:"
 
 #: ../src/pages/map/popup.vue ../src/pages/map/popup.vue:388
 msgid ""
-"Report the issue as improper, if according to you is not an issue. The issue"
-" will not be displayed to anyone more."
+"Report the issue as improper, if it is not an issue according to you. The "
+"issue will not be displayed to anyone anymore."
 msgstr "Segnala l’errore come improprio se a parer tuo non si tratta di un errore. L’errore non sarà più visibile a nessuno."
 
 #: ../src/pages/map/popup.vue:402
 msgid ""
-"After issue fixed on the OSM data, mark it as done. May also disappear "
-"automatically on next check if no more issue."
+"After fixing the issue in the OSM data, mark it as done. It will also "
+"disappear automatically on the next check."
 msgstr "Dopo aver risolto l’errore sui dati OSM, segnalalo come risolto. Potrebbe anche non comparire più automaticamente al prossimo controllo qualora non venisse rilevato un errore."
 
 #: ../../tools/database/items_menu.txt:44
@@ -1594,7 +1594,7 @@ msgstr "Statistiche per l’utente {user}"
 #: ../src/pages/byuser/byuser.vue:45
 msgid ""
 "This page shows issues on elements that were last modified by '{users}'. "
-"This doesn't means that this user is responsible for all these issues."
+"This doesn't mean that this user is responsible for all these issues."
 msgstr "Questa pagina mostra i problemi per gli elementi che sono stati modificati l’ultima volta da '{users}'. Ciò non significa che tale utente abbia inserito tutti quegli errori."
 
 #: ../src/pages/byuser/byuser.vue:7

--- a/web/po/ja.po
+++ b/web/po/ja.po
@@ -5,13 +5,16 @@
 # Translators:
 # Kit Tak <misc.takashi@gmail.com>, 2020
 # Lratz sc, 2023
+# Lratz sc, 2023
 # 藤本 理弘 <mfujimot@gmail.com>, 2014
 # Satoshi IIDA <nyampire@gmail.com>, 2016
+# OKADA Tsuneo, 2020
 # OKADA Tsuneo, 2020
 # Satoshi IIDA <nyampire@gmail.com>, 2016
 # Shu Higashi, 2020-2021
 # Tom Konda <tom.konda.dev@gmail.com>, 2020
 # tomoya muramoto <muramototomoya@gmail.com>, 2016
+# 藤本 理弘 <mfujimot@gmail.com>, 2014
 # 藤本 理弘 <mfujimot@gmail.com>, 2014
 msgid ""
 msgstr ""
@@ -19,8 +22,8 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2014-03-18 22:25+0100\n"
 "PO-Revision-Date: 2014-04-28 19:22+0000\n"
-"Last-Translator: Lratz sc, 2023\n"
-"Language-Team: Japanese (http://www.transifex.com/openstreetmap-france/osmose/language/ja/)\n"
+"Last-Translator: 藤本 理弘 <mfujimot@gmail.com>, 2014\n"
+"Language-Team: Japanese (http://app.transifex.com/openstreetmap-france/osmose/language/ja/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -823,7 +826,7 @@ msgid "gas station"
 msgstr "ガソリンスタンド"
 
 #: ../src/pages/map/editor.vue:4
-msgid "You must be logged in order to use the tag editor"
+msgid "You must be logged in to use the tag editor"
 msgstr "タグエディタを使うにはログインが必要です"
 
 #: ../src/pages/map/editor-modal.vue:2
@@ -1228,14 +1231,14 @@ msgstr "報告日:"
 
 #: ../src/pages/map/popup.vue ../src/pages/map/popup.vue:388
 msgid ""
-"Report the issue as improper, if according to you is not an issue. The issue"
-" will not be displayed to anyone more."
+"Report the issue as improper, if it is not an issue according to you. The "
+"issue will not be displayed to anyone anymore."
 msgstr "あなたから見て問題でない場合は誤検出であることを報告してください。問題はそれ以上表示されなくなります。"
 
 #: ../src/pages/map/popup.vue:402
 msgid ""
-"After issue fixed on the OSM data, mark it as done. May also disappear "
-"automatically on next check if no more issue."
+"After fixing the issue in the OSM data, mark it as done. It will also "
+"disappear automatically on the next check."
 msgstr "OSMデータの問題を解決したら、完了とマークして下さい。他に問題がなければ、次回のチェック時に自動的に消えるかも知れません。"
 
 #: ../../tools/database/items_menu.txt:44
@@ -1591,7 +1594,7 @@ msgstr "{user}さんの統計"
 #: ../src/pages/byuser/byuser.vue:45
 msgid ""
 "This page shows issues on elements that were last modified by '{users}'. "
-"This doesn't means that this user is responsible for all these issues."
+"This doesn't mean that this user is responsible for all these issues."
 msgstr "このページで表示されている課題は、最後に'{users}'さんが変更した要素を意味しています。このユーザにすべての責任があるわけではありません。"
 
 #: ../src/pages/byuser/byuser.vue:7

--- a/web/po/lt.po
+++ b/web/po/lt.po
@@ -11,7 +11,7 @@ msgstr ""
 "POT-Creation-Date: 2014-03-18 22:25+0100\n"
 "PO-Revision-Date: 2014-04-28 19:22+0000\n"
 "Last-Translator: Aurimas Fišeras <aurimas@members.fsf.org>, 2015-2016\n"
-"Language-Team: Lithuanian (http://www.transifex.com/openstreetmap-france/osmose/language/lt/)\n"
+"Language-Team: Lithuanian (http://app.transifex.com/openstreetmap-france/osmose/language/lt/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -814,7 +814,7 @@ msgid "gas station"
 msgstr "degalinė"
 
 #: ../src/pages/map/editor.vue:4
-msgid "You must be logged in order to use the tag editor"
+msgid "You must be logged in to use the tag editor"
 msgstr "Privalote prisijungti žymų rengyklei naudoti"
 
 #: ../src/pages/map/editor-modal.vue:2
@@ -1219,14 +1219,14 @@ msgstr ""
 
 #: ../src/pages/map/popup.vue ../src/pages/map/popup.vue:388
 msgid ""
-"Report the issue as improper, if according to you is not an issue. The issue"
-" will not be displayed to anyone more."
+"Report the issue as improper, if it is not an issue according to you. The "
+"issue will not be displayed to anyone anymore."
 msgstr ""
 
 #: ../src/pages/map/popup.vue:402
 msgid ""
-"After issue fixed on the OSM data, mark it as done. May also disappear "
-"automatically on next check if no more issue."
+"After fixing the issue in the OSM data, mark it as done. It will also "
+"disappear automatically on the next check."
 msgstr ""
 
 #: ../../tools/database/items_menu.txt:44
@@ -1582,7 +1582,7 @@ msgstr ""
 #: ../src/pages/byuser/byuser.vue:45
 msgid ""
 "This page shows issues on elements that were last modified by '{users}'. "
-"This doesn't means that this user is responsible for all these issues."
+"This doesn't mean that this user is responsible for all these issues."
 msgstr ""
 
 #: ../src/pages/byuser/byuser.vue:7

--- a/web/po/nb.po
+++ b/web/po/nb.po
@@ -11,7 +11,7 @@ msgstr ""
 "POT-Creation-Date: 2014-03-18 22:25+0100\n"
 "PO-Revision-Date: 2014-04-28 19:22+0000\n"
 "Last-Translator: Syver S. Stensholt <sssandum@gmail.com>, 2019-2020\n"
-"Language-Team: Norwegian Bokmål (http://www.transifex.com/openstreetmap-france/osmose/language/nb/)\n"
+"Language-Team: Norwegian Bokmål (http://app.transifex.com/openstreetmap-france/osmose/language/nb/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -814,7 +814,7 @@ msgid "gas station"
 msgstr "bensinstasjon"
 
 #: ../src/pages/map/editor.vue:4
-msgid "You must be logged in order to use the tag editor"
+msgid "You must be logged in to use the tag editor"
 msgstr "Du må være logget for å kunne bruke egenskapsredigereren"
 
 #: ../src/pages/map/editor-modal.vue:2
@@ -1219,14 +1219,14 @@ msgstr "Problem rapportert på:"
 
 #: ../src/pages/map/popup.vue ../src/pages/map/popup.vue:388
 msgid ""
-"Report the issue as improper, if according to you is not an issue. The issue"
-" will not be displayed to anyone more."
+"Report the issue as improper, if it is not an issue according to you. The "
+"issue will not be displayed to anyone anymore."
 msgstr "Rapporter problemet som en falsk positiv, hvis deu mener det ikke er et problem. Problemet vil ikke vises til noen som helst lenger."
 
 #: ../src/pages/map/popup.vue:402
 msgid ""
-"After issue fixed on the OSM data, mark it as done. May also disappear "
-"automatically on next check if no more issue."
+"After fixing the issue in the OSM data, mark it as done. It will also "
+"disappear automatically on the next check."
 msgstr "Etter problemet er fikset i OSM, marker som fullført. Kan også bli borte automatisk ved neste sjekk hvis problemet er borte."
 
 #: ../../tools/database/items_menu.txt:44
@@ -1582,7 +1582,7 @@ msgstr ""
 #: ../src/pages/byuser/byuser.vue:45
 msgid ""
 "This page shows issues on elements that were last modified by '{users}'. "
-"This doesn't means that this user is responsible for all these issues."
+"This doesn't mean that this user is responsible for all these issues."
 msgstr ""
 
 #: ../src/pages/byuser/byuser.vue:7

--- a/web/po/nl.po
+++ b/web/po/nl.po
@@ -13,17 +13,19 @@
 # frodrigo <fred.rodrigo@gmail.com>, 2017
 # Dimas, 2020-2021
 # Oli Vier, 2022
+# Oli Vier, 2022
 # operon, 2012
 # operon, 2012
 # d8c0ea79bf25224e2a05d5edf10ab5e4_c9b605c, 2014,2017-2020
+# Thibault Molleman <transifex.tp1by@thibaultmol.link>, 2023
 msgid ""
 msgstr ""
 "Project-Id-Version: Osmose\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2014-03-18 22:25+0100\n"
 "PO-Revision-Date: 2014-04-28 19:22+0000\n"
-"Last-Translator: Famlam, 2022-2023\n"
-"Language-Team: Dutch (http://www.transifex.com/openstreetmap-france/osmose/language/nl/)\n"
+"Last-Translator: operon, 2012\n"
+"Language-Team: Dutch (http://app.transifex.com/openstreetmap-france/osmose/language/nl/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -826,7 +828,7 @@ msgid "gas station"
 msgstr "benzine station"
 
 #: ../src/pages/map/editor.vue:4
-msgid "You must be logged in order to use the tag editor"
+msgid "You must be logged in to use the tag editor"
 msgstr "U moet ingelogd zijn om de tag editor te gebruiken"
 
 #: ../src/pages/map/editor-modal.vue:2
@@ -1231,14 +1233,14 @@ msgstr "Melding gemeld op:"
 
 #: ../src/pages/map/popup.vue ../src/pages/map/popup.vue:388
 msgid ""
-"Report the issue as improper, if according to you is not an issue. The issue"
-" will not be displayed to anyone more."
+"Report the issue as improper, if it is not an issue according to you. The "
+"issue will not be displayed to anyone anymore."
 msgstr "Meld de melding als ongepast, als het volgens u geen fout betreft. De melding wordt aan niemand meer getoond."
 
 #: ../src/pages/map/popup.vue:402
 msgid ""
-"After issue fixed on the OSM data, mark it as done. May also disappear "
-"automatically on next check if no more issue."
+"After fixing the issue in the OSM data, mark it as done. It will also "
+"disappear automatically on the next check."
 msgstr "Nadat het probleem is opgelost in de OSM data, markeert u het als hersteld. Kan ook automatisch verdwijnen bij de volgende controle als er geen melding meer is."
 
 #: ../../tools/database/items_menu.txt:44
@@ -1594,7 +1596,7 @@ msgstr "Statistieken voor gebruiker {user} "
 #: ../src/pages/byuser/byuser.vue:45
 msgid ""
 "This page shows issues on elements that were last modified by '{users}'. "
-"This doesn't means that this user is responsible for all these issues."
+"This doesn't mean that this user is responsible for all these issues."
 msgstr "Deze pagina toont meldingen met elementen die het laatst zijn gewijzigd door '{users}'. Dit betekent niet dat deze gebruiker verantwoordelijk is voor al deze meldingen. "
 
 #: ../src/pages/byuser/byuser.vue:7
@@ -1821,8 +1823,8 @@ msgstr "zijweg"
 
 #: ../../web_api/byuser.py:96
 msgid "Statistics for user {}"
-msgstr ""
+msgstr "Statistieken voor gebruiker {}"
 
 #: ../src/pages/issues/index.vue:279
 msgid "{{ showAnalyserCount }} / {{ errors_groups.length }} rows. Show more."
-msgstr ""
+msgstr "{{ showAnalyserCount }} / {{ errors_groups.length }} rijen. Meer weergeven.\n "

--- a/web/po/osmose-frontend.pot
+++ b/web/po/osmose-frontend.pot
@@ -812,7 +812,7 @@ msgid "gas station"
 msgstr ""
 
 #: ../src/pages/map/editor.vue:4
-msgid "You must be logged in order to use the tag editor"
+msgid "You must be logged in to use the tag editor"
 msgstr ""
 
 #: ../src/pages/map/editor-modal.vue:2
@@ -1216,14 +1216,14 @@ msgstr ""
 
 #: ../src/pages/map/popup.vue ../src/pages/map/popup.vue:388
 msgid ""
-"Report the issue as improper, if according to you is not an issue. The issue "
-"will not be displayed to anyone more."
+"Report the issue as improper, if it is not an issue according to you. The "
+"issue will not be displayed to anyone anymore."
 msgstr ""
 
 #: ../src/pages/map/popup.vue:402
 msgid ""
-"After issue fixed on the OSM data, mark it as done. May also disappear "
-"automatically on next check if no more issue."
+"After fixing the issue in the OSM data, mark it as done. It will also "
+"disappear automatically on the next check."
 msgstr ""
 
 #: ../../tools/database/items_menu.txt:44
@@ -1579,7 +1579,7 @@ msgstr ""
 #: ../src/pages/byuser/byuser.vue:45
 msgid ""
 "This page shows issues on elements that were last modified by '{users}'. "
-"This doesn't means that this user is responsible for all these issues."
+"This doesn't mean that this user is responsible for all these issues."
 msgstr ""
 
 #: ../src/pages/byuser/byuser.vue:7

--- a/web/po/pl.po
+++ b/web/po/pl.po
@@ -5,6 +5,7 @@
 # Translators:
 # Daniel Koć <daniel@xn--ko-wla.pl>, 2014
 # Dave Ska, 2022
+# Dave Ska, 2022
 # Debeat <krystian4842@gmail.com>, 2015
 # endro, 2014-2016
 # endro, 2014
@@ -15,7 +16,7 @@
 # maro21 OSM, 2019
 # maro21 OSM, 2019-2021
 # Teiron, 2016
-# Piotr Strębski <strebski@gmail.com>, 2022
+# Piotr Strębski <strebski@gmail.com>, 2022-2023
 # endro, 2014
 # Teiron, 2016
 msgid ""
@@ -24,8 +25,8 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2014-03-18 22:25+0100\n"
 "PO-Revision-Date: 2014-04-28 19:22+0000\n"
-"Last-Translator: Piotr Strębski <strebski@gmail.com>, 2022\n"
-"Language-Team: Polish (http://www.transifex.com/openstreetmap-france/osmose/language/pl/)\n"
+"Last-Translator: Teiron, 2016\n"
+"Language-Team: Polish (http://app.transifex.com/openstreetmap-france/osmose/language/pl/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -828,7 +829,7 @@ msgid "gas station"
 msgstr "stacja paliw"
 
 #: ../src/pages/map/editor.vue:4
-msgid "You must be logged in order to use the tag editor"
+msgid "You must be logged in to use the tag editor"
 msgstr "Musisz być zalogowany, aby używać edytora tagów"
 
 #: ../src/pages/map/editor-modal.vue:2
@@ -1233,14 +1234,14 @@ msgstr "Problem wykryto:"
 
 #: ../src/pages/map/popup.vue ../src/pages/map/popup.vue:388
 msgid ""
-"Report the issue as improper, if according to you is not an issue. The issue"
-" will not be displayed to anyone more."
+"Report the issue as improper, if it is not an issue according to you. The "
+"issue will not be displayed to anyone anymore."
 msgstr "Zgłoś ten problem jako niewłaściwy, jeśli według ciebie to nie błąd. Problem nie będzie się już wyświetlał."
 
 #: ../src/pages/map/popup.vue:402
 msgid ""
-"After issue fixed on the OSM data, mark it as done. May also disappear "
-"automatically on next check if no more issue."
+"After fixing the issue in the OSM data, mark it as done. It will also "
+"disappear automatically on the next check."
 msgstr "Po naprawieniu błędu na OSM, oznacz jako zrobione. Ten problem zniknie też automatycznie po następnym sprawdzeniu, jeśli nie będzie już błędu."
 
 #: ../../tools/database/items_menu.txt:44
@@ -1596,7 +1597,7 @@ msgstr "Statystyki użytkownika {users}"
 #: ../src/pages/byuser/byuser.vue:45
 msgid ""
 "This page shows issues on elements that were last modified by '{users}'. "
-"This doesn't means that this user is responsible for all these issues."
+"This doesn't mean that this user is responsible for all these issues."
 msgstr "Ta strona pokazuje problemy z elementami, które były ostatnio edytowane przez użytkownika {users}. To nie oznacza, że ten użytkownik odpowiada za te wszystkie błędy."
 
 #: ../src/pages/byuser/byuser.vue:7
@@ -1660,35 +1661,35 @@ msgstr "skrzynka pocztowa, nr ref. nie zintegrowany"
 
 #: ../../tools/database/items_menu.txt:116
 msgid "school, ref not integrated"
-msgstr ""
+msgstr "szkoła, ref nie jest zintegrowany"
 
 #: ../../tools/database/items_menu.txt:123
 msgid "transport sharing, ref not integrated"
-msgstr ""
+msgstr "wypożyczalnia pojazdów, ref nie jest zintegrowany"
 
 #: ../../tools/database/items_menu.txt:124
 msgid "pharmacy, ref not integrated"
-msgstr ""
+msgstr "apteka, ref nie jest zintegrowany"
 
 #: ../../tools/database/items_menu.txt:125
 msgid "postal code, ref not integrated"
-msgstr ""
+msgstr "kod pocztowy, ref nie jest zintegrowany"
 
 #: ../../tools/database/items_menu.txt:127
 msgid "power substation, ref not integrated"
-msgstr ""
+msgstr "podstacja elektryczna, ref nie jest zintegrowany"
 
 #: ../../tools/database/items_menu.txt:128
 msgid "hospital, ref not integrated"
-msgstr ""
+msgstr "szpital, ref nie jest zintegrowany"
 
 #: ../../tools/database/items_menu.txt:129
 msgid "social facility, ref not integrated"
-msgstr ""
+msgstr "ośrodek pomocy społecznej, ref nie jest zintegrowany"
 
 #: ../../tools/database/items_menu.txt:130
 msgid "medical lab, ref not integrated"
-msgstr ""
+msgstr "laboratorium medyczne, ref nie jest zintegrowany"
 
 #: ../../tools/database/items_menu.txt:131
 msgid "gas station, ref not integrated"
@@ -1819,12 +1820,12 @@ msgstr "warunkowe ograniczenia"
 
 #: ../../tools/database/items_menu.txt:79
 msgid "sideway"
-msgstr ""
+msgstr "boczna droga"
 
 #: ../../web_api/byuser.py:96
 msgid "Statistics for user {}"
-msgstr ""
+msgstr "Statystyki dla użytkownika {}"
 
 #: ../src/pages/issues/index.vue:279
 msgid "{{ showAnalyserCount }} / {{ errors_groups.length }} rows. Show more."
-msgstr ""
+msgstr "{{ showAnalyserCount }} / {{ errors_groups.length }} rzędów. Pokaż więcej."

--- a/web/po/pt.po
+++ b/web/po/pt.po
@@ -18,7 +18,7 @@ msgstr ""
 "POT-Creation-Date: 2014-03-18 22:25+0100\n"
 "PO-Revision-Date: 2014-04-28 19:22+0000\n"
 "Last-Translator: Rui <xymarior@yandex.com>, 2016-2019\n"
-"Language-Team: Portuguese (http://www.transifex.com/openstreetmap-france/osmose/language/pt/)\n"
+"Language-Team: Portuguese (http://app.transifex.com/openstreetmap-france/osmose/language/pt/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -821,7 +821,7 @@ msgid "gas station"
 msgstr "estação de combustível"
 
 #: ../src/pages/map/editor.vue:4
-msgid "You must be logged in order to use the tag editor"
+msgid "You must be logged in to use the tag editor"
 msgstr "Tem de ter a sessão iniciada para usar o editor de etiquetas"
 
 #: ../src/pages/map/editor-modal.vue:2
@@ -1226,14 +1226,14 @@ msgstr "Erro reportado em:"
 
 #: ../src/pages/map/popup.vue ../src/pages/map/popup.vue:388
 msgid ""
-"Report the issue as improper, if according to you is not an issue. The issue"
-" will not be displayed to anyone more."
+"Report the issue as improper, if it is not an issue according to you. The "
+"issue will not be displayed to anyone anymore."
 msgstr "Reportar o erro como impróprio, se não considerar um erro. O erro não será mostrado a mais ninguém."
 
 #: ../src/pages/map/popup.vue:402
 msgid ""
-"After issue fixed on the OSM data, mark it as done. May also disappear "
-"automatically on next check if no more issue."
+"After fixing the issue in the OSM data, mark it as done. It will also "
+"disappear automatically on the next check."
 msgstr "Após o erro ser corrigido nos dados do OSM, marque-o como resolvido. Pode também desaparecer automaticamente na próxima verificação se não houver mais problemas."
 
 #: ../../tools/database/items_menu.txt:44
@@ -1589,7 +1589,7 @@ msgstr ""
 #: ../src/pages/byuser/byuser.vue:45
 msgid ""
 "This page shows issues on elements that were last modified by '{users}'. "
-"This doesn't means that this user is responsible for all these issues."
+"This doesn't mean that this user is responsible for all these issues."
 msgstr ""
 
 #: ../src/pages/byuser/byuser.vue:7

--- a/web/po/pt_BR.po
+++ b/web/po/pt_BR.po
@@ -6,6 +6,7 @@
 # André Marcelo Alvarenga <alvarenga@kde.org>, 2016,2019
 # Eduardo Addad de Oliveira <eduardoaddad@hotmail.com>, 2019-2020
 # Matheus Gomes, 2022
+# Matheus Gomes, 2022
 # OpenStreetMap contributor Paulo, 2014
 # Rui <xymarior@yandex.com>, 2016,2018-2019
 # Thiago Vieira <thipvieira@gmail.com>, 2014
@@ -16,8 +17,8 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2014-03-18 22:25+0100\n"
 "PO-Revision-Date: 2014-04-28 19:22+0000\n"
-"Last-Translator: Matheus Gomes, 2022\n"
-"Language-Team: Portuguese (Brazil) (http://www.transifex.com/openstreetmap-france/osmose/language/pt_BR/)\n"
+"Last-Translator: ViriatoLusitano <marcosoliveira.2405@gmail.com>, 2014\n"
+"Language-Team: Portuguese (Brazil) (http://app.transifex.com/openstreetmap-france/osmose/language/pt_BR/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -820,7 +821,7 @@ msgid "gas station"
 msgstr "posto de combustível"
 
 #: ../src/pages/map/editor.vue:4
-msgid "You must be logged in order to use the tag editor"
+msgid "You must be logged in to use the tag editor"
 msgstr "Tem de ter a sessão iniciada para usar o editor de etiquetas"
 
 #: ../src/pages/map/editor-modal.vue:2
@@ -1225,14 +1226,14 @@ msgstr "Erro reportado em:"
 
 #: ../src/pages/map/popup.vue ../src/pages/map/popup.vue:388
 msgid ""
-"Report the issue as improper, if according to you is not an issue. The issue"
-" will not be displayed to anyone more."
+"Report the issue as improper, if it is not an issue according to you. The "
+"issue will not be displayed to anyone anymore."
 msgstr "Reportar o erro como impróprio, se não considerar um erro. O erro não será mostrado a mais ninguém."
 
 #: ../src/pages/map/popup.vue:402
 msgid ""
-"After issue fixed on the OSM data, mark it as done. May also disappear "
-"automatically on next check if no more issue."
+"After fixing the issue in the OSM data, mark it as done. It will also "
+"disappear automatically on the next check."
 msgstr "Após o erro ser corrigido nos dados do OSM, marque-o como resolvido. Pode também desaparecer automaticamente na próxima verificação se não houver mais problemas."
 
 #: ../../tools/database/items_menu.txt:44
@@ -1588,7 +1589,7 @@ msgstr "Estatísticas do usuário {user}"
 #: ../src/pages/byuser/byuser.vue:45
 msgid ""
 "This page shows issues on elements that were last modified by '{users}'. "
-"This doesn't means that this user is responsible for all these issues."
+"This doesn't mean that this user is responsible for all these issues."
 msgstr "Esta página mostra erros em elementos reportados que foram alterados na última vez por '{users}'. Isto não quer dizer que este usuário foi responsável por criar todos esses erros."
 
 #: ../src/pages/byuser/byuser.vue:7

--- a/web/po/ro.po
+++ b/web/po/ro.po
@@ -18,8 +18,8 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2014-03-18 22:25+0100\n"
 "PO-Revision-Date: 2014-04-28 19:22+0000\n"
-"Last-Translator: Mircea Vutcovici <mirceavutcovici@gmail.com>, 2018,2020\n"
-"Language-Team: Romanian (http://www.transifex.com/openstreetmap-france/osmose/language/ro/)\n"
+"Last-Translator: Rădulescu Răzvan <radulescu.razvan@gmail.com>, 2014\n"
+"Language-Team: Romanian (http://app.transifex.com/openstreetmap-france/osmose/language/ro/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -822,7 +822,7 @@ msgid "gas station"
 msgstr "benzinărie"
 
 #: ../src/pages/map/editor.vue:4
-msgid "You must be logged in order to use the tag editor"
+msgid "You must be logged in to use the tag editor"
 msgstr "Trebuie să fiți autentificat pentru a utiliza editorul de tag-uri"
 
 #: ../src/pages/map/editor-modal.vue:2
@@ -1227,14 +1227,14 @@ msgstr ""
 
 #: ../src/pages/map/popup.vue ../src/pages/map/popup.vue:388
 msgid ""
-"Report the issue as improper, if according to you is not an issue. The issue"
-" will not be displayed to anyone more."
+"Report the issue as improper, if it is not an issue according to you. The "
+"issue will not be displayed to anyone anymore."
 msgstr ""
 
 #: ../src/pages/map/popup.vue:402
 msgid ""
-"After issue fixed on the OSM data, mark it as done. May also disappear "
-"automatically on next check if no more issue."
+"After fixing the issue in the OSM data, mark it as done. It will also "
+"disappear automatically on the next check."
 msgstr ""
 
 #: ../../tools/database/items_menu.txt:44
@@ -1590,7 +1590,7 @@ msgstr ""
 #: ../src/pages/byuser/byuser.vue:45
 msgid ""
 "This page shows issues on elements that were last modified by '{users}'. "
-"This doesn't means that this user is responsible for all these issues."
+"This doesn't mean that this user is responsible for all these issues."
 msgstr ""
 
 #: ../src/pages/byuser/byuser.vue:7

--- a/web/po/ru.po
+++ b/web/po/ru.po
@@ -5,6 +5,8 @@
 # Translators:
 # 4004 <transifex.4004@mailhero.io>, 2017
 # d1g <acroq3@gmail.com>, 2015
+# BusteR <lyamin2712@rambler.ru>, 2021
+# c394013dcb5ad6c5d23f7e651e436f84_bb9d5bc <edc2dec0855294e6c29efc8eacdb5ae6_826732>, 2019
 # d1g <acroq3@gmail.com>, 2015
 # frodrigo <fred.rodrigo@gmail.com>, 2017
 # frodrigo <fred.rodrigo@gmail.com>, 2017
@@ -18,14 +20,15 @@
 # 4004 <transifex.4004@mailhero.io>, 2017
 # c394013dcb5ad6c5d23f7e651e436f84_bb9d5bc <edc2dec0855294e6c29efc8eacdb5ae6_826732>, 2019
 # Андрей Коваленко, 2020
+# Андрей Коваленко, 2020
 msgid ""
 msgstr ""
 "Project-Id-Version: Osmose\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2014-03-18 22:25+0100\n"
 "PO-Revision-Date: 2014-04-28 19:22+0000\n"
-"Last-Translator: BusteR <lyamin2712@rambler.ru>, 2021\n"
-"Language-Team: Russian (http://www.transifex.com/openstreetmap-france/osmose/language/ru/)\n"
+"Last-Translator: Андрей Коваленко, 2020\n"
+"Language-Team: Russian (http://app.transifex.com/openstreetmap-france/osmose/language/ru/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -828,7 +831,7 @@ msgid "gas station"
 msgstr "автозаправка"
 
 #: ../src/pages/map/editor.vue:4
-msgid "You must be logged in order to use the tag editor"
+msgid "You must be logged in to use the tag editor"
 msgstr "Вы должны войти чтобы воспользоваться редактором тегов"
 
 #: ../src/pages/map/editor-modal.vue:2
@@ -1233,14 +1236,14 @@ msgstr "Ошибку обнаружили в:"
 
 #: ../src/pages/map/popup.vue ../src/pages/map/popup.vue:388
 msgid ""
-"Report the issue as improper, if according to you is not an issue. The issue"
-" will not be displayed to anyone more."
+"Report the issue as improper, if it is not an issue according to you. The "
+"issue will not be displayed to anyone anymore."
 msgstr "Сообщить о проблеме как неверной, если вы считаете что это не ошибка. Она больше не будет всем видна."
 
 #: ../src/pages/map/popup.vue:402
 msgid ""
-"After issue fixed on the OSM data, mark it as done. May also disappear "
-"automatically on next check if no more issue."
+"After fixing the issue in the OSM data, mark it as done. It will also "
+"disappear automatically on the next check."
 msgstr "После исправления ошибки в данных OSM, пометить как решённое. Также может исчезнуть автоматически при следующей проверке."
 
 #: ../../tools/database/items_menu.txt:44
@@ -1596,7 +1599,7 @@ msgstr "Статистика для пользователя {user}"
 #: ../src/pages/byuser/byuser.vue:45
 msgid ""
 "This page shows issues on elements that were last modified by '{users}'. "
-"This doesn't means that this user is responsible for all these issues."
+"This doesn't mean that this user is responsible for all these issues."
 msgstr ""
 
 #: ../src/pages/byuser/byuser.vue:7

--- a/web/po/sv.po
+++ b/web/po/sv.po
@@ -4,6 +4,8 @@
 # 
 # Translators:
 # danieldegroot2 <danieldegroot18@gmail.com>, 2021
+# danieldegroot2 <danieldegroot18@gmail.com>, 2021
+# Magnus Österlund, 2020,2022
 # Magnus Österlund, 2020,2022
 msgid ""
 msgstr ""
@@ -12,7 +14,7 @@ msgstr ""
 "POT-Creation-Date: 2014-03-18 22:25+0100\n"
 "PO-Revision-Date: 2014-04-28 19:22+0000\n"
 "Last-Translator: Magnus Österlund, 2020,2022\n"
-"Language-Team: Swedish (http://www.transifex.com/openstreetmap-france/osmose/language/sv/)\n"
+"Language-Team: Swedish (http://app.transifex.com/openstreetmap-france/osmose/language/sv/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -815,7 +817,7 @@ msgid "gas station"
 msgstr ""
 
 #: ../src/pages/map/editor.vue:4
-msgid "You must be logged in order to use the tag editor"
+msgid "You must be logged in to use the tag editor"
 msgstr ""
 
 #: ../src/pages/map/editor-modal.vue:2
@@ -1220,14 +1222,14 @@ msgstr ""
 
 #: ../src/pages/map/popup.vue ../src/pages/map/popup.vue:388
 msgid ""
-"Report the issue as improper, if according to you is not an issue. The issue"
-" will not be displayed to anyone more."
+"Report the issue as improper, if it is not an issue according to you. The "
+"issue will not be displayed to anyone anymore."
 msgstr ""
 
 #: ../src/pages/map/popup.vue:402
 msgid ""
-"After issue fixed on the OSM data, mark it as done. May also disappear "
-"automatically on next check if no more issue."
+"After fixing the issue in the OSM data, mark it as done. It will also "
+"disappear automatically on the next check."
 msgstr ""
 
 #: ../../tools/database/items_menu.txt:44
@@ -1583,7 +1585,7 @@ msgstr ""
 #: ../src/pages/byuser/byuser.vue:45
 msgid ""
 "This page shows issues on elements that were last modified by '{users}'. "
-"This doesn't means that this user is responsible for all these issues."
+"This doesn't mean that this user is responsible for all these issues."
 msgstr ""
 
 #: ../src/pages/byuser/byuser.vue:7

--- a/web/po/uk.po
+++ b/web/po/uk.po
@@ -3,12 +3,13 @@
 # This file is distributed under the same license as the osmose-frontend package.
 # 
 # Translators:
-# Andrey Golovin, 2014,2018
-# Andrey Golovin, 2018,2020
+# Andrey Golovin, 2014,2018,2020
+# Andrii Holovin, 2018,2020
 # andygol, 2014
-# Andrey Golovin, 2014
+# Andrii Holovin, 2014
 # frodrigo <fred.rodrigo@gmail.com>, 2017
 # frodrigo <fred.rodrigo@gmail.com>, 2017
+# Green Aloe, 2022
 # Green Aloe, 2022
 # Serhii Murza <jhellico@gmail.com>, 2018
 # Viktor <avatarsnk@gmail.com>, 2015
@@ -20,8 +21,8 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2014-03-18 22:25+0100\n"
 "PO-Revision-Date: 2014-04-28 19:22+0000\n"
-"Last-Translator: Green Aloe, 2022\n"
-"Language-Team: Ukrainian (http://www.transifex.com/openstreetmap-france/osmose/language/uk/)\n"
+"Last-Translator: Viktor <avatarsnk@gmail.com>, 2015\n"
+"Language-Team: Ukrainian (http://app.transifex.com/openstreetmap-france/osmose/language/uk/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -824,7 +825,7 @@ msgid "gas station"
 msgstr "АЗС"
 
 #: ../src/pages/map/editor.vue:4
-msgid "You must be logged in order to use the tag editor"
+msgid "You must be logged in to use the tag editor"
 msgstr "Для користування редактором теґів вам слід залоґінитися"
 
 #: ../src/pages/map/editor-modal.vue:2
@@ -1229,14 +1230,14 @@ msgstr "Повідомлення про проблему:"
 
 #: ../src/pages/map/popup.vue ../src/pages/map/popup.vue:388
 msgid ""
-"Report the issue as improper, if according to you is not an issue. The issue"
-" will not be displayed to anyone more."
+"Report the issue as improper, if it is not an issue according to you. The "
+"issue will not be displayed to anyone anymore."
 msgstr "Повідомте про помилку, як про невідповідну, якщо ви вважаєте, що це не помилка. Повідомлення більше не з'являтиметься."
 
 #: ../src/pages/map/popup.vue:402
 msgid ""
-"After issue fixed on the OSM data, mark it as done. May also disappear "
-"automatically on next check if no more issue."
+"After fixing the issue in the OSM data, mark it as done. It will also "
+"disappear automatically on the next check."
 msgstr "Після виправлення помилки в OSM позначте її як вирішена. Можливо також, що вона зникне автоматично при наступній перевірці, якщо більше не виникатиме."
 
 #: ../../tools/database/items_menu.txt:44
@@ -1592,7 +1593,7 @@ msgstr "Статистика по користувачу {user}"
 #: ../src/pages/byuser/byuser.vue:45
 msgid ""
 "This page shows issues on elements that were last modified by '{users}'. "
-"This doesn't means that this user is responsible for all these issues."
+"This doesn't mean that this user is responsible for all these issues."
 msgstr "На цій сторінці відображені проблеми з елементами, які останнім часом були змінені '{users}'. Це зовсім не означає, що цей користувач несе відповідальність за всі ці проблеми."
 
 #: ../src/pages/byuser/byuser.vue:7

--- a/web/po/vi.po
+++ b/web/po/vi.po
@@ -11,7 +11,7 @@ msgstr ""
 "POT-Creation-Date: 2014-03-18 22:25+0100\n"
 "PO-Revision-Date: 2014-04-28 19:22+0000\n"
 "Last-Translator: Minh Nguyễn <minh@nguyen.cincinnati.oh.us>, 2020\n"
-"Language-Team: Vietnamese (http://www.transifex.com/openstreetmap-france/osmose/language/vi/)\n"
+"Language-Team: Vietnamese (http://app.transifex.com/openstreetmap-france/osmose/language/vi/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -814,7 +814,7 @@ msgid "gas station"
 msgstr ""
 
 #: ../src/pages/map/editor.vue:4
-msgid "You must be logged in order to use the tag editor"
+msgid "You must be logged in to use the tag editor"
 msgstr ""
 
 #: ../src/pages/map/editor-modal.vue:2
@@ -1219,14 +1219,14 @@ msgstr ""
 
 #: ../src/pages/map/popup.vue ../src/pages/map/popup.vue:388
 msgid ""
-"Report the issue as improper, if according to you is not an issue. The issue"
-" will not be displayed to anyone more."
+"Report the issue as improper, if it is not an issue according to you. The "
+"issue will not be displayed to anyone anymore."
 msgstr ""
 
 #: ../src/pages/map/popup.vue:402
 msgid ""
-"After issue fixed on the OSM data, mark it as done. May also disappear "
-"automatically on next check if no more issue."
+"After fixing the issue in the OSM data, mark it as done. It will also "
+"disappear automatically on the next check."
 msgstr ""
 
 #: ../../tools/database/items_menu.txt:44
@@ -1582,7 +1582,7 @@ msgstr ""
 #: ../src/pages/byuser/byuser.vue:45
 msgid ""
 "This page shows issues on elements that were last modified by '{users}'. "
-"This doesn't means that this user is responsible for all these issues."
+"This doesn't mean that this user is responsible for all these issues."
 msgstr ""
 
 #: ../src/pages/byuser/byuser.vue:7

--- a/web/po/zh_CN.po
+++ b/web/po/zh_CN.po
@@ -4,17 +4,18 @@
 # 
 # Translators:
 # anodern, 2021
+# anodern, 2021
 # Elizabeth Sherrock <lizzyd710@gmail.com>, 2021
 # jie x, 2017-2020,2022
-# Steve Lee <stevel2520@gmail.com>, 2020
+# Steve Lee <stevel2520@gmail.com>, 2020,2023
 msgid ""
 msgstr ""
 "Project-Id-Version: Osmose\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2014-03-18 22:25+0100\n"
 "PO-Revision-Date: 2014-04-28 19:22+0000\n"
-"Last-Translator: jie x, 2017-2020,2022\n"
-"Language-Team: Chinese (China) (http://www.transifex.com/openstreetmap-france/osmose/language/zh_CN/)\n"
+"Last-Translator: Steve Lee <stevel2520@gmail.com>, 2020,2023\n"
+"Language-Team: Chinese (China) (http://app.transifex.com/openstreetmap-france/osmose/language/zh_CN/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -817,7 +818,7 @@ msgid "gas station"
 msgstr "加油站"
 
 #: ../src/pages/map/editor.vue:4
-msgid "You must be logged in order to use the tag editor"
+msgid "You must be logged in to use the tag editor"
 msgstr "您必须登录才能使用标签编辑器"
 
 #: ../src/pages/map/editor-modal.vue:2
@@ -1222,14 +1223,14 @@ msgstr "报告问题："
 
 #: ../src/pages/map/popup.vue ../src/pages/map/popup.vue:388
 msgid ""
-"Report the issue as improper, if according to you is not an issue. The issue"
-" will not be displayed to anyone more."
+"Report the issue as improper, if it is not an issue according to you. The "
+"issue will not be displayed to anyone anymore."
 msgstr "反馈问题不合理，如果根据你反馈这不是问题那此问题不会再显示给其他人。"
 
 #: ../src/pages/map/popup.vue:402
 msgid ""
-"After issue fixed on the OSM data, mark it as done. May also disappear "
-"automatically on next check if no more issue."
+"After fixing the issue in the OSM data, mark it as done. It will also "
+"disappear automatically on the next check."
 msgstr "在OSM数据上修复问题后，将其标记为已完成。如果没有别的问题，可能在下次检查时自动消失。"
 
 #: ../../tools/database/items_menu.txt:44
@@ -1585,7 +1586,7 @@ msgstr "用户 {user} 的统计"
 #: ../src/pages/byuser/byuser.vue:45
 msgid ""
 "This page shows issues on elements that were last modified by '{users}'. "
-"This doesn't means that this user is responsible for all these issues."
+"This doesn't mean that this user is responsible for all these issues."
 msgstr "本页面显示的问题是由最后修改者 '{users}' 编辑。这并不表示这些问题都由该用户造成。"
 
 #: ../src/pages/byuser/byuser.vue:7

--- a/web/po/zh_TW.po
+++ b/web/po/zh_TW.po
@@ -8,14 +8,15 @@
 # jie x, 2018
 # Kuang-che Wu <kcwu@csie.org>, 2016
 # Sean Young <assanges@icloud.com>, 2017-2018
+# Steve Lee <stevel2520@gmail.com>, 2023
 msgid ""
 msgstr ""
 "Project-Id-Version: Osmose\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2014-03-18 22:25+0100\n"
 "PO-Revision-Date: 2014-04-28 19:22+0000\n"
-"Last-Translator: Supaplex <bejokeup@gmail.com>, 2017-2020,2022\n"
-"Language-Team: Chinese (Taiwan) (http://www.transifex.com/openstreetmap-france/osmose/language/zh_TW/)\n"
+"Last-Translator: Kuang-che Wu <kcwu@csie.org>, 2016\n"
+"Language-Team: Chinese (Taiwan) (http://app.transifex.com/openstreetmap-france/osmose/language/zh_TW/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -818,7 +819,7 @@ msgid "gas station"
 msgstr "加油站"
 
 #: ../src/pages/map/editor.vue:4
-msgid "You must be logged in order to use the tag editor"
+msgid "You must be logged in to use the tag editor"
 msgstr "你必須登入才能使用標籤編輯器"
 
 #: ../src/pages/map/editor-modal.vue:2
@@ -1223,14 +1224,14 @@ msgstr "問題發現日期："
 
 #: ../src/pages/map/popup.vue ../src/pages/map/popup.vue:388
 msgid ""
-"Report the issue as improper, if according to you is not an issue. The issue"
-" will not be displayed to anyone more."
+"Report the issue as improper, if it is not an issue according to you. The "
+"issue will not be displayed to anyone anymore."
 msgstr "若你認為此問題無不適切之處，請回報此問題為不適當。 此問題將不再顯示予任何人。"
 
 #: ../src/pages/map/popup.vue:402
 msgid ""
-"After issue fixed on the OSM data, mark it as done. May also disappear "
-"automatically on next check if no more issue."
+"After fixing the issue in the OSM data, mark it as done. It will also "
+"disappear automatically on the next check."
 msgstr "在修復OSM資料數據問題後，請將其標記為已完成。如果沒有更多問題，也可能在下次檢查時自動消失。"
 
 #: ../../tools/database/items_menu.txt:44
@@ -1586,7 +1587,7 @@ msgstr "{user} 使用者的統計數據"
 #: ../src/pages/byuser/byuser.vue:45
 msgid ""
 "This page shows issues on elements that were last modified by '{users}'. "
-"This doesn't means that this user is responsible for all these issues."
+"This doesn't mean that this user is responsible for all these issues."
 msgstr "這一頁顯示由 '{users}'. 最後編輯的物件問題，這並不表示該位使用者需要為這些問題負責。"
 
 #: ../src/pages/byuser/byuser.vue:7
@@ -1805,7 +1806,7 @@ msgstr "放大來檢視問題"
 
 #: ../../tools/database/items_menu.txt:78
 msgid "conditional restriction"
-msgstr ""
+msgstr "條件限制"
 
 #: ../../tools/database/items_menu.txt:79
 msgid "sideway"

--- a/web/src/pages/byuser/byuser.vue
+++ b/web/src/pages/byuser/byuser.vue
@@ -62,7 +62,7 @@
       <p>
         <translate :params="{ users: users.join('\', \'') }">
           This page shows issues on elements that were last modified by
-          '{users}'. This doesn't means that this user is responsible for all
+          '{users}'. This doesn't mean that this user is responsible for all
           these issues.
         </translate>
       </p>

--- a/web/src/pages/map/editor.vue
+++ b/web/src/pages/map/editor.vue
@@ -2,7 +2,7 @@
   <div id="editor" :data-user="!!user">
     <div v-if="!user">
       <p>
-        <translate>You must be logged in order to use the tag editor</translate>
+        <translate>You must be logged in to use the tag editor</translate>
       </p>
       <a href="../login"><translate>Login</translate></a>
     </div>

--- a/web/src/pages/map/popup.vue
+++ b/web/src/pages/map/popup.vue
@@ -260,7 +260,7 @@
                 $t('false positive') +
                 ' - ' +
                 $t(
-                  'Report the issue as improper, if according to you is not an issue. The issue will not be displayed to anyone more.'
+                  'Report the issue as improper, if it is not an issue according to you. The issue will not be displayed to anyone anymore.'
                 )
               "
               @click="setFalsePositive(uuid)"
@@ -276,7 +276,7 @@
                 $t('corrected') +
                 ' - ' +
                 $t(
-                  'After issue fixed on the OSM data, mark it as done. May also disappear automatically on next check if no more issue.'
+                  'After fixing the issue in the OSM data, mark it as done. It will also disappear automatically on the next check.'
                 )
               "
               @click="setDone(uuid)"
@@ -396,7 +396,7 @@ export default Vue.extend({
 
     setFalsePositive(uuid: string): void {
       const message = this.$t(
-        'Report the issue as improper, if according to you is not an issue. The issue will not be displayed to anyone more.'
+        'Report the issue as improper, if it is not an issue according to you. The issue will not be displayed to anyone anymore.'
       )
       if (confirm(message)) {
         fetch(API_URL + `/api/0.3/issue/${uuid}/false`)


### PR DESCRIPTION
Fix some English typos (see also https://github.com/osm-fr/osmose-backend/issues/1731#issuecomment-1435965143 )

@jocelynj I don't think this will affect any non-English translations since they're just typos, so would it be possible to run your script once again to update them automatically? E.g. without deleting the existing translations?