### PR TITLE
fix typo "usename" instead of "username"

### DIFF
--- a/web/src/pages/byuser/byuser.vue
+++ b/web/src/pages/byuser/byuser.vue
@@ -148,7 +148,7 @@ export default VueParent.extend({
     api_url_path(format: string, query: string): string {
       return `${this.website}/api/0.3/issues${format ? '.' + format : ''}?${
         this.query
-      }&usename=${this.username}${query ? '&' + query : ''}`
+      }&username=${this.username}${query ? '&' + query : ''}`
     },
 
     render(): void {


### PR DESCRIPTION
which is producing broken links for user-only .rss, .gpx, .csv... 

(invalid parameter "usename" was being ignored, thus returning all results, instead of results filtered only for specified user)

Fixes https://github.com/osm-fr/osmose-frontend/issues/467