### PR TITLE
Update Github Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,10 +11,10 @@ jobs:
         USER: root
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
This PR update:
- [checkout ](https://github.com/actions/checkout)to v3
- [setup-python](https://github.com/actions/setup-python) to v4

Github remove support to actions using node 12 -> https://github.blog/changelog/2023-07-17-github-actions-removal-of-node12-from-the-actions-runner/