### PR TITLE
Use preferred tile.openstreetmap.org URL, use direct HTTPS URL for OpenStreetMap copyright

### DIFF
--- a/web/static/map/layers.ts
+++ b/web/static/map/layers.ts
@@ -5,10 +5,10 @@ import Mapillary from './Mapillary'
 import 'leaflet-plugins/layer/tile/Bing'
 
 const osmAttribution =
-  '&copy <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+  '&copy <a href="https://openstreetmap.org/copyright">OpenStreetMap</a> contributors'
 export const mapBases = {
   // OpenStreetMap
-  carto: L.tileLayer('//{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+  carto: L.tileLayer('//tile.openstreetmap.org/{z}/{x}/{y}.png', {
     attribution: osmAttribution,
   }),
   CyclOSM: L.tileLayer(


### PR DESCRIPTION
I would like to suggest using the now preferred https://tile.openstreetmap.org URL instead of the current one (`{s}`), see

https://github.com/openstreetmap/operations/issues/737

and use direct HTTPS URL for OpenStreetMap copyright page which redirects from HTTP to HTTPS.