### PR TITLE
Google Cache has stopped working, at least for me

### DIFF
--- a/api/tool/tag2link_sources.json
+++ b/api/tool/tag2link_sources.json
@@ -432,12 +432,6 @@
       "rank": "normal"
     },
     {
-      "key": "Key:contact:website",
-      "url": "https://webcache.googleusercontent.com/search?q=cache:$1",
-      "source": "wikidata:P3303",
-      "rank": "normal"
-    },
-    {
       "key": "Key:contact:yelp",
       "url": "https://www.yelp.com/biz/$1",
       "source": "osmwiki:P8",
@@ -2510,12 +2504,6 @@
     {
       "key": "Key:website",
       "url": "https://web.archive.org/web/*/$1/",
-      "source": "wikidata:P3303",
-      "rank": "normal"
-    },
-    {
-      "key": "Key:website",
-      "url": "https://webcache.googleusercontent.com/search?q=cache:$1",
       "source": "wikidata:P3303",
       "rank": "normal"
     },


### PR DESCRIPTION
related to #531 but is not a real fix to it

warning: not tested

Google Cache (at least for me) simply does not work and returns 

> did not match any documents.
>
>Suggestions:
>
>    Make sure that all words are spelled correctly.
>    Try different keywords.
>    Try more general keywords.

for all websites that were linked from Osmose (these websites were up)