### PR TITLE
Replace vue-top-progress with nprogress

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@maplibre/maplibre-gl-geocoder": "^1.5.0",
         "@types/geojson": "^7946.0.14",
+        "@types/nprogress": "^0.2.3",
         "babel-preset-typescript-vue": "^1.1.1",
         "bootstrap": "^4.6.0",
         "geobuf": "^3.0.2",
@@ -18,13 +19,13 @@
         "lodash": "^4.17.21",
         "maplibre-gl": "^4.3.2",
         "marked": "^12.0.2",
+        "nprogress": "^0.2.0",
         "numeral": "^2.0.6",
         "vue": "^2.6.12",
         "vue-filter-number-format": "^3.0.1",
         "vue-i18n": "^8.24.2",
         "vue-router": "^3.5.1",
         "vue-sorted-table": "^1.3.0",
-        "vue-top-progress": "^0.7.0",
         "vue2-timeago": "^1.2.10"
       },
       "devDependencies": {
@@ -2477,6 +2478,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/nprogress": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@types/nprogress/-/nprogress-0.2.3.tgz",
+      "integrity": "sha512-k7kRA033QNtC+gLc4VPlfnue58CM1iQLgn1IMAU8VPHGOj7oIHPp9UlhedEnD/Gl8evoCjwkZjlBORtZ3JByUA==",
+      "license": "MIT"
     },
     "node_modules/@types/pbf": {
       "version": "3.0.5",
@@ -6458,6 +6465,21 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -8102,6 +8124,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/nprogress": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/nprogress/-/nprogress-0.2.0.tgz",
+      "integrity": "sha512-I19aIingLgR1fmhftnbWWO3dXc0hSxqHQHQb3H8m+K3TnEn/iSeTZZOyvKXWqQESMwuUVnatlCnZdLBZZt2VSA==",
+      "license": "MIT"
     },
     "node_modules/nth-check": {
       "version": "2.1.1",
@@ -10967,11 +10995,6 @@
       "resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz",
       "integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==",
       "dev": true
-    },
-    "node_modules/vue-top-progress": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/vue-top-progress/-/vue-top-progress-0.7.0.tgz",
-      "integrity": "sha512-pkZQuT3yxkRtB3QvrL2eF1h/F01JbJaI3eqdiM4CGZbsexLKJctYRolGHzK87c11moyx+aK8lwzeq8aPPoNOqA=="
     },
     "node_modules/vue/node_modules/@vue/compiler-sfc": {
       "version": "2.7.16",

--- a/web/package.json
+++ b/web/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "@maplibre/maplibre-gl-geocoder": "^1.5.0",
     "@types/geojson": "^7946.0.14",
+    "@types/nprogress": "^0.2.3",
     "babel-preset-typescript-vue": "^1.1.1",
     "bootstrap": "^4.6.0",
     "geobuf": "^3.0.2",
@@ -16,13 +17,13 @@
     "lodash": "^4.17.21",
     "maplibre-gl": "^4.3.2",
     "marked": "^12.0.2",
+    "nprogress": "^0.2.0",
     "numeral": "^2.0.6",
     "vue": "^2.6.12",
     "vue-filter-number-format": "^3.0.1",
     "vue-i18n": "^8.24.2",
     "vue-router": "^3.5.1",
     "vue-sorted-table": "^1.3.0",
-    "vue-top-progress": "^0.7.0",
     "vue2-timeago": "^1.2.10"
   },
   "devDependencies": {

--- a/web/src/components/issues-list.vue
+++ b/web/src/components/issues-list.vue
@@ -1,6 +1,5 @@
 <template>
   <div>
-    <vue-topprogress ref="topProgress"></vue-topprogress>
     <div v-if="error">{{ error }}</div>
     <div v-else-if="errors">
       <sorted-table

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -1,8 +1,9 @@
+import 'nprogress/nprogress.css'
+
 import numeral from 'numeral'
 import Vue from 'vue'
 import numFormat from 'vue-filter-number-format'
 import SortedTablePlugin from 'vue-sorted-table'
-import vueTopprogress from 'vue-top-progress'
 
 import App from './app.vue'
 import TranslateSlot from './components/translate-slot.vue'
@@ -10,7 +11,6 @@ import Translate from './components/translate.vue'
 import { i18n, loadLanguageAsync } from './i18n'
 import { router } from './router'
 
-Vue.use(vueTopprogress)
 Vue.use(SortedTablePlugin)
 Vue.filter('numFormat', numFormat(numeral))
 Vue.component('Translate', Translate)

--- a/web/src/pages/Parent.vue
+++ b/web/src/pages/Parent.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import NProgress from 'nprogress'
 import Vue from 'vue'
 
 export default Vue.extend({
@@ -35,15 +36,15 @@ export default Vue.extend({
     },
 
     fetchJsonProgress(url, callback = (response: Object) => {}) {
-      this.$refs.topProgress.start()
+      NProgress.start()
       this.fetchJson(
         url,
         (response) => {
-          this.$refs.topProgress.done()
+          NProgress.done()
           callback(response)
         },
         () => {
-          this.$refs.topProgress.done()
+          NProgress.done()
         }
       )
     },

--- a/web/src/pages/byuser/byuser.vue
+++ b/web/src/pages/byuser/byuser.vue
@@ -1,6 +1,5 @@
 <template>
   <div>
-    <vue-topprogress ref="topProgress"></vue-topprogress>
     <div v-if="error">{{ error }}</div>
     <div v-else>
       <nav

--- a/web/src/pages/control/update.vue
+++ b/web/src/pages/control/update.vue
@@ -1,6 +1,5 @@
 <template>
   <div>
-    <vue-topprogress ref="topProgress"></vue-topprogress>
     <div v-if="error">{{ error }}</div>
     <table
       v-else

--- a/web/src/pages/control/update_matrix.vue
+++ b/web/src/pages/control/update_matrix.vue
@@ -1,6 +1,5 @@
 <template>
   <div>
-    <vue-topprogress ref="topProgress"></vue-topprogress>
     <div v-if="error">{{ error }}</div>
     <table
       v-else

--- a/web/src/pages/control/update_summary.vue
+++ b/web/src/pages/control/update_summary.vue
@@ -1,6 +1,5 @@
 <template>
   <div>
-    <vue-topprogress ref="topProgress"></vue-topprogress>
     <div v-if="error">{{ error }}</div>
     <table
       v-else

--- a/web/src/pages/control/update_summary_by_analyser.vue
+++ b/web/src/pages/control/update_summary_by_analyser.vue
@@ -1,6 +1,5 @@
 <template>
   <div>
-    <vue-topprogress ref="topProgress"></vue-topprogress>
     <div v-if="error">{{ error }}</div>
     <table
       v-else

--- a/web/src/pages/issue/index.vue
+++ b/web/src/pages/issue/index.vue
@@ -1,6 +1,5 @@
 <template>
   <div>
-    <vue-topprogress ref="topProgress"></vue-topprogress>
     <div v-if="error">{{ error }}</div>
     <div v-else>
       <h2><translate>Marker</translate></h2>

--- a/web/src/pages/issues/index.vue
+++ b/web/src/pages/issues/index.vue
@@ -1,6 +1,5 @@
 <template>
   <div>
-    <vue-topprogress ref="topProgress"></vue-topprogress>
     <div v-if="error">{{ error }}</div>
     <div v-else>
       <nav

--- a/web/src/pages/issues/matrix.vue
+++ b/web/src/pages/issues/matrix.vue
@@ -1,6 +1,5 @@
 <template>
   <div style="font-size: 50%">
-    <vue-topprogress ref="topProgress"></vue-topprogress>
     <div v-if="error">{{ error }}</div>
     <table
       v-else

--- a/web/src/pages/map/index.vue
+++ b/web/src/pages/map/index.vue
@@ -1,6 +1,5 @@
 <template>
   <div>
-    <vue-topprogress ref="topProgress"></vue-topprogress>
     <div v-if="error">{{ error }}</div>
     <div>
       <top


### PR DESCRIPTION
The vue-top-progress hasn't had updates in 8 years and won't be compatible with vue3, nprogress is depending on neither vue versions and is actively maintained.